### PR TITLE
disableRestoreFocus=true on elementSearchDialog

### DIFF
--- a/src/components/ElementSearchDialog/element-search-dialog.js
+++ b/src/components/ElementSearchDialog/element-search-dialog.js
@@ -74,6 +74,7 @@ const ElementSearchDialog = (props) => {
         <Dialog
             open={open}
             onClose={onClose}
+            disableRestoreFocus={true}
             aria-labelledby="dialog-title-search"
             fullWidth={true}
         >


### PR DESCRIPTION
Signed-off-by: Abdelsalem <abdelsalem.hedhili@rte-france.com>