### PR TITLE
Fix warning for OverflowableText

### DIFF
--- a/src/components/OverflowableText/overflowable-text.js
+++ b/src/components/OverflowableText/overflowable-text.js
@@ -61,7 +61,7 @@ export const OverflowableText = ({ text, className, children, ...props }) => {
 
 OverflowableText.propTypes = {
     children: PropTypes.array,
-    text: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    text: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     className: PropTypes.string,
 };
 


### PR DESCRIPTION
Warning: Failed prop type: The prop `text` is marked as required in `OverflowableText`, but its value is `undefined`. could be undefined or null, then remove its required characteristic

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>