### PR TITLE
fix(warning): React does not recognize the `setExpanded` prop on a DOM element.

### DIFF
--- a/src/components/ElementSearchDialog/element-search-dialog.js
+++ b/src/components/ElementSearchDialog/element-search-dialog.js
@@ -93,7 +93,6 @@ const ElementSearchDialog = (props) => {
                             ...optionProps,
                             element,
                             inputValue,
-                            setExpanded,
                             onClose: handleClose,
                         })
                     }


### PR DESCRIPTION
 If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `setexpanded` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>