### PR TITLE
Refactor ElementSearchDialog : Remove useless internal elements state

### DIFF
--- a/src/components/ElementSearchDialog/element-search-dialog.js
+++ b/src/components/ElementSearchDialog/element-search-dialog.js
@@ -26,15 +26,12 @@ const ElementSearchDialog = (props) => {
         renderElement,
     } = props;
 
-    const [elements, setElements] = useState([]);
-
     const [expanded, setExpanded] = useState(false);
 
     const [loading, setLoading] = useState(false);
 
     useEffect(() => {
         setLoading(false);
-        setElements(elementsFound);
     }, [elementsFound]);
 
     const handleSearchTermChange = (term) => {
@@ -43,14 +40,12 @@ const ElementSearchDialog = (props) => {
             onSearchTermChange(term);
             setExpanded(true);
         } else {
-            setElements([]);
             setExpanded(false);
         }
     };
 
     const handleClose = useCallback(() => {
         setExpanded(false);
-        setElements([]);
         onClose();
     }, [onClose]);
 
@@ -67,9 +62,6 @@ const ElementSearchDialog = (props) => {
                     id="element-search"
                     forcePopupIcon={false}
                     open={expanded}
-                    onOpen={() => {
-                        setElements([]);
-                    }}
                     onClose={() => {
                         setExpanded(false);
                     }}
@@ -82,13 +74,13 @@ const ElementSearchDialog = (props) => {
                     isOptionEqualToValue={(option, value) =>
                         option.id === value.id
                     }
-                    options={elements}
+                    options={loading ? [] : elementsFound}
                     loading={loading}
                     autoHighlight={true}
                     noOptionsText={intl.formatMessage({
                         id: 'element_search/noResult',
                     })}
-                    renderOption={(optionProps, element, { inputValue }) =>
+                    renderOption={(optionProps, element, { inputValue }) => 
                         renderElement({
                             ...optionProps,
                             element,


### PR DESCRIPTION
It doubles complexity and rendering behavior

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>