### PR TITLE
Needs node v12 at least for project importing this dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "common react components for gridsuite applications",
     "engines": {
         "npm": "<=6",
-        "node": "<=14"
+        "node": ">=12 <=14"
     },
     "main": "lib/index.js",
     "files": [


### PR DESCRIPTION
chore(): It doesn't work anymore wih node v10, needs node v12 at least. Every project importing this commons-ui dependency will be warn if installed with an older version of node.

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>