### PR TITLE
Fix AuthService: Fix expires_in value which was set too late 

### DIFF
--- a/src/utils/AuthService.js
+++ b/src/utils/AuthService.js
@@ -291,11 +291,16 @@ function handleUser(dispatch, userManager, validateUser) {
                         console.log(
                             'Error in silent renew, but idtoken ALMOST expiring (expiring in' +
                                 idTokenExpiresIn +
-                                ') => last chance' +
+                                ') => last chance, next error will logout',
+                            'maxExpiresIn = ' +
                                 userManager.idpSettings.maxExpiresIn,
+                            'last renew attempt in ' +
+                                idTokenExpiresIn -
+                                accessTokenExpiringNotificationTime +
+                                'seconds',
                             error
                         );
-                        user.expires_in = userManager.idpSettings.maxExpiresIn;
+                        user.expires_in = idTokenExpiresIn;
                         userManager.storeUser(user).then(() => {
                             userManager.getUser();
                         });


### PR DESCRIPTION
the user expires_in value was set too late for the last renewal attempt when token is about to expire.

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>