### PR TITLE
Refactor MuiVirtualizedTable headerRenderer : Avoid nested React Components

### DIFF
--- a/demo/src/TableTab.js
+++ b/demo/src/TableTab.js
@@ -43,7 +43,7 @@ const styles = (theme) => ({
     header: {
         backgroundColor: theme.palette.info.light,
         color: theme.palette.primary.contrastText,
-        fontWeight: 'bold',
+        fontWeight: 'bold', // TODO: this doesn't overwrite header column font weight
     },
     rowBackgroundDark: {
         backgroundColor: theme.palette.info.dark,
@@ -65,8 +65,9 @@ export const TableTab = () => {
     const columns = useMemo(
         () => [
             {
-                label: 'header1',
+                label: 'header1 (clickable cells in column)',
                 dataKey: 'key1',
+                clickable: true,
             },
             {
                 label: 'header2',
@@ -90,7 +91,13 @@ export const TableTab = () => {
     const rows = useMemo(
         () => [
             { key1: 'group2', key2: 'val2', key3: 1, key4: 2.35 },
-            { key1: 'group1', key2: 'val1', key3: 2, key4: 5.32 },
+            {
+                key1: 'group1 (not clickable line)',
+                key2: 'val1',
+                key3: 2,
+                key4: 5.32,
+                notClickable: true,
+            },
             { key1: 'group2', key2: 'val4', key3: 3, key4: 23.5 },
             { key1: 'group1', key2: 'val3', key3: 4, key4: 52.3 },
             { key1: 'group3', key2: 'val3', key3: 5, key4: 2.53 },

--- a/demo/src/TableTab.js
+++ b/demo/src/TableTab.js
@@ -63,7 +63,7 @@ const styles = (theme) => ({
     header: {
         backgroundColor: theme.palette.info.light,
         color: theme.palette.primary.contrastText,
-        fontWeight: 'bold', // TODO: this doesn't overwrite header column font weight
+        fontWeight: 'bolder',
     },
     rowBackgroundDark: {
         backgroundColor: theme.palette.info.dark,

--- a/src/components/MuiVirtualizedTable/ColumnHeader.js
+++ b/src/components/MuiVirtualizedTable/ColumnHeader.js
@@ -15,10 +15,7 @@ import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 
 const useStyles = makeStyles((theme) => ({
-    label: {
-        fontWeight: 'bold',
-        fontSize: '0.875rem', // to mimic TableCellRoot 'binding'
-    },
+    label: {},
     divFlex: {
         display: 'flex',
         flexDirection: 'row',


### PR DESCRIPTION
Refactor headerRenderer and set/use columnData and rowData to avoid array access when not necessary

+ fix Avoid nested React Components

![image (4)](https://user-images.githubusercontent.com/6103727/218057492-843690ca-094e-43b6-b83b-8fcc916c0428.png)
![image (5)](https://user-images.githubusercontent.com/6103727/218057559-a0228539-4433-4846-8e23-77bdf25c05fa.png)
![image (6)](https://user-images.githubusercontent.com/6103727/218057604-ef882441-87f7-4d9d-9095-6e1e18cbdaa0.png)

Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>