### PR TITLE
Replace the french translation of "equipment"

### DIFF
--- a/src/components/translations/equipment-search-fr.js
+++ b/src/components/translations/equipment-search-fr.js
@@ -6,7 +6,7 @@
  */
 
 const equipment_search_fr = {
-    'equipment_search/label': 'Rechercher un équipement',
+    'equipment_search/label': 'Rechercher un ouvrage',
     'equipment_search/switchTag': 'SWITCH',
     'equipment_search/busbarSectionTag': 'SJB',
     'equipment_search/lineTag': 'LIGNE',

--- a/src/components/translations/top-bar-fr.js
+++ b/src/components/translations/top-bar-fr.js
@@ -12,7 +12,7 @@ const top_bar_fr = {
     'top-bar/exitFullScreen': 'Quitter mode plein écran',
     'top-bar/about': 'A propos',
     'top-bar/displayMode': "Mode d'affichage",
-    'top-bar/equipmentLabel': 'Label des équipements',
+    'top-bar/equipmentLabel': 'Label des ouvrages',
     'top-bar/id': 'Id',
     'top-bar/name': 'Nom',
     'top-bar/language': 'Langue',


### PR DESCRIPTION
Replace the french translation of "equipment" from ""equipement" to "ouvrage"