### PR TITLE
Fix demo equipment search regression after 9122a87

### DIFF
--- a/demo/data/EquipmentSearchBar.js
+++ b/demo/data/EquipmentSearchBar.js
@@ -132,6 +132,20 @@ const EQUIPMENTS = [
         voltageLevels: [{ id: 'vl10', name: 'vl10' }],
         networkUuid: NETWORK_UUID,
     },
+    {
+        id: 'ident11',
+        name: '',
+        type: 'BUS',
+        voltageLevels: [{ id: 'vl10', name: 'vl10' }],
+        networkUuid: NETWORK_UUID,
+    },
+    {
+        id: 'ident15',
+        // no name for testing
+        type: 'BUS',
+        voltageLevels: [{ id: 'vl10', name: 'vl10' }],
+        networkUuid: NETWORK_UUID,
+    },
 ];
 
 export const searchEquipments = (searchTerm, equipmentLabelling) => {
@@ -139,12 +153,12 @@ export const searchEquipments = (searchTerm, equipmentLabelling) => {
         return getEquipmentsInfosForSearchBar(
             equipmentLabelling
                 ? EQUIPMENTS.filter((equipment) =>
-                      equipment.name.includes(searchTerm)
+                      (equipment.name || equipment.id).includes(searchTerm)
                   )
                 : EQUIPMENTS.filter((equipment) =>
                       equipment.id.includes(searchTerm)
                   ),
-            equipmentLabelling
+            equipmentLabelling ? (e) => e.name || e.id : (e) => e.id
         );
     } else {
         return [];


### PR DESCRIPTION
when typing charcters in the search top bar, the app crashes with:

Uncaught TypeError: getNameOrId is not a function
    getEquipmentsInfosForSearchBar EquipmentType.js:120
    getEquipmentsInfosForSearchBar EquipmentType.js:119
    searchEquipments EquipmentSearchBar.js:139
    searchMatchingEquipments app.js:299
    handleSearchTermChange element-search-dialog.js:40
    onInputChange element-search-dialog.js:71
    handleInputChange useAutocomplete.js:775
    handleChange InputBase.js:356