### PR TITLE
Fixes the bad contrast and border of selected lines in report-item.js.

### DIFF
--- a/src/components/ReportViewer/report-item.js
+++ b/src/components/ReportViewer/report-item.js
@@ -23,8 +23,8 @@ const useReportItemStyles = makeStyles((theme) => ({
     },
     content: {
         color: theme.palette.text.secondary,
-        borderTopRightRadius: theme.spacing(2),
-        borderBottomRightRadius: theme.spacing(2),
+        borderRadius: theme.spacing(2),
+        width: 'fit-content',
         paddingRight: theme.spacing(1),
         fontWeight: theme.typography.fontWeightMedium,
         '&$expanded': {
@@ -33,11 +33,12 @@ const useReportItemStyles = makeStyles((theme) => ({
         /* &&.Mui-focused to increase specifity because mui5 has a rule for &.Mui-selected.Mui-focused */
         /* &&$selected to increase specifity because we have a rule for &:hover > $content on root */
         '&&.Mui-focused, &&$selected': {
-            backgroundColor: `var(--tree-view-bg-color, ${theme.palette.grey[400]})`,
+            backgroundColor: `var(--tree-view-bg-color, ${theme.palette.action.selected})`,
             color: 'var(--tree-view-color)',
         },
         // same as mui v4 behavior on label text only right after clicking in contrast to after moving away with arrow keys.
         '&$selected $label:hover, &$selected.Mui-focused $label': {
+            borderRadius: theme.spacing(2),
             backgroundColor: alpha(
                 theme.palette.primary.main,
                 theme.palette.action.selectedOpacity +


### PR DESCRIPTION
In commons-ui demo, when we open "LOGS", the left panel used to have bad contrast between the selected lines' background color and font color, the left side of the selected line had right angles and the background was truncated if we moves the scrollbar.

This change fixes the contrast, smooth the left selected-line border, and expands its background to fix an issue when moving the scrollbar.