### PR TITLE
Fix commons-ui version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@gridsuite/commons-ui",
-            "version": "0.35.4",
+            "version": "0.35.6",
             "license": "MPL",
             "dependencies": {
                 "autosuggest-highlight": "^3.2.0",


### PR DESCRIPTION
commons-ui version was erroneous in package-lock, npm install fix this on main