### PR TITLE
Fix Warning OverflowableText sx propTypes

### DIFF
--- a/src/components/OverflowableText/overflowable-text.js
+++ b/src/components/OverflowableText/overflowable-text.js
@@ -87,7 +87,11 @@ OverflowableText.propTypes = {
     ]),
     tooltipStyle: PropTypes.string,
     tooltipSx: PropTypes.object,
-    sx: PropTypes.object,
+    sx: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.array,
+        PropTypes.func,
+    ]),
     className: PropTypes.string,
 };
 


### PR DESCRIPTION
fix(OverflowableText): fix sx propTypes to avoid warning when using arrays (mergeSx) for the sx props.

Warning: Failed prop type: Invalid prop `sx` of type `array` supplied to `Styled(Component)`, expected `object`.