### PR TITLE
Fix ElementSearchDialog: Add clearOnBlur prop 

### DIFF
--- a/src/components/ElementSearchDialog/element-search-dialog.js
+++ b/src/components/ElementSearchDialog/element-search-dialog.js
@@ -83,6 +83,7 @@ const ElementSearchDialog = (props) => {
                     }}
                     fullWidth
                     freeSolo
+                    clearOnBlur
                     onInputChange={(_event, value) => {
                         if (!searchTermDisabled) {
                             handleSearchTermChange(value);


### PR DESCRIPTION
Because even with value=null when in FreeSolo mode the AutoComplete remains the value in the input.