### PR TITLE
Fix ElementSearchDialog Autocomplete onChange. 

### DIFF
--- a/src/components/ElementSearchDialog/element-search-dialog.js
+++ b/src/components/ElementSearchDialog/element-search-dialog.js
@@ -89,9 +89,13 @@ const ElementSearchDialog = (props) => {
                             handleSearchTermChange(value);
                         }
                     }}
-                    onChange={(_event, newValue) => {
-                        onSelectionChange(newValue);
-                        setValue(null);
+                    onChange={(_event, newValue, reason) => {
+                        if (reason === 'selectOption') {
+                            onSelectionChange(newValue);
+                            setValue(newValue);
+                        } else {
+                            setValue(null);
+                        }
                     }}
                     getOptionLabel={(option) => option.label}
                     isOptionEqualToValue={(option, value) =>


### PR DESCRIPTION
diff reasons were introduce when passing Autocomplete in freesolo mode, then we should manage onSelectionChange depending on those reasons.