### PR TITLE
Update float regex validation

### DIFF
--- a/src/components/react-hook-form/numbers/utils.js
+++ b/src/components/react-hook-form/numbers/utils.js
@@ -1,7 +1,7 @@
 export const isIntegerNumber = (val) => {
-    return /^-?[0-9]*$/.test(val);
+    return /^-?[0-9]+$/.test(val);
 };
 
 export const isFloatNumber = (val) => {
-    return /^-?[0-9]*[.,]?[0-9]*$/.test(val);
+    return /^-?(?:[0-9]+(?:[.,][0-9]*)?|[.][0-9]+)(?:[eE]-?[0-9]+)?$/.test(val);
 };

--- a/src/components/react-hook-form/numbers/utils.js
+++ b/src/components/react-hook-form/numbers/utils.js
@@ -3,5 +3,5 @@ export const isIntegerNumber = (val) => {
 };
 
 export const isFloatNumber = (val) => {
-    return /^-?(?:[0-9]+(?:[.,][0-9]*)?|[.][0-9]+)(?:[eE]-?[0-9]+)?$/.test(val);
+    return /^-?(?:[0-9]+(?:[.,][0-9]*)?|[.,][0-9]+)(?:[eE]-?[0-9]+)?$/.test(val);
 };

--- a/src/components/react-hook-form/numbers/utils.js
+++ b/src/components/react-hook-form/numbers/utils.js
@@ -3,5 +3,5 @@ export const isIntegerNumber = (val) => {
 };
 
 export const isFloatNumber = (val) => {
-    return /^-?(?:[0-9]+(?:[.,][0-9]*)?|[.,][0-9]+)(?:[eE]-?[0-9]+)?$/.test(val);
+    return /^[-+]?(?:[0-9]+(?:[.,][0-9]*)?|[.,][0-9]+)(?:[eE][-+]?[0-9]+)?$/.test(val);
 };


### PR DESCRIPTION
Based on `parseFloat()` accepted values, adding support for some formats of float notations:
* `.1`
* `1.`
* exponentials: `1e2`, `1e-2`, `1.2e3`, ...

Also reject case with only `.` or `e1`.