### PR TITLE
Problem modifying or deleting exponential values in form fields

### DIFF
--- a/src/components/react-hook-form/numbers/float-input.js
+++ b/src/components/react-hook-form/numbers/float-input.js
@@ -15,6 +15,15 @@ const FloatInput = (props) => {
         if (['-', '.'].includes(sanitizedValue)) {
             return sanitizedValue;
         }
+
+        // support editing exponential format
+        if (
+            sanitizedValue &&
+            (sanitizedValue.includes('e') || sanitizedValue.includes('E'))
+        ) {
+            return sanitizedValue;
+        }
+
         return sanitizedValue === null || isNaN(sanitizedValue)
             ? ''
             : sanitizedValue;
@@ -32,6 +41,12 @@ const FloatInput = (props) => {
         if (tmp.endsWith('.') || tmp.endsWith('0')) {
             return tmp;
         }
+
+        // support editing exponential format
+        if (tmp.includes('e') || tmp.includes('E')) {
+            return tmp;
+        }
+
         return parseFloat(tmp) || null;
     };
 

--- a/src/components/react-hook-form/numbers/utils.js
+++ b/src/components/react-hook-form/numbers/utils.js
@@ -3,5 +3,5 @@ export const isIntegerNumber = (val) => {
 };
 
 export const isFloatNumber = (val) => {
-    return /^-?[0-9]*[.,]?[0-9]*$/.test(val);
+    return /^-?[0-9]*[.,]?[0-9]*([eE][-+]?[0-9]*)?$/.test(val);
 };

--- a/src/components/react-hook-form/numbers/utils.js
+++ b/src/components/react-hook-form/numbers/utils.js
@@ -2,6 +2,7 @@ export const isIntegerNumber = (val) => {
     return /^-?[0-9]*$/.test(val);
 };
 
+// litmit the exponential part to two digits and <= 20 ([0-9]|1[0-9]|20)?
 export const isFloatNumber = (val) => {
-    return /^-?[0-9]*[.,]?[0-9]*([eE][-+]?[0-9]*)?$/.test(val);
+    return /^-?[0-9]*[.,]?[0-9]*([eE][-+]?([0-9]|1[0-9]|20)?)?$/.test(val);
 };


### PR DESCRIPTION
When very large values are entered in the form fields, they are displayed in scientific notation. The contents of the field can no longer be modified or deleted using the keyboard.

![image](https://github.com/gridsuite/commons-ui/assets/117309322/afce28f7-16dc-44a4-a4cd-fcc01753834d)

At the first time, need to do is enter numbers between e-20 and e+20.

After correction:

 
![rhf_float_input](https://github.com/gridsuite/commons-ui/assets/117309322/046b859d-d698-4e14-bc52-0c85b810237e)

