### PR TITLE
Remove old jss system

### DIFF
--- a/demo/src/TableTab.jsx
+++ b/demo/src/TableTab.jsx
@@ -22,7 +22,7 @@ import MuiVirtualizedTable, {
 import { CHANGE_WAYS } from '../../src/components/MuiVirtualizedTable/KeyedColumnsRowIndexer';
 import { toNestedGlobalSelectors } from '../../src/utils/styles';
 
-// For demo and fun.. all even numbers first, then all ascending odd numbers, only postive numbers..
+// For demo and fun... all even numbers first, then all ascending odd numbers, only positive numbers...
 const evenThenOddOrderingKey = (n) => {
     const remainder = Math.abs(n % 2);
     if (n <= 0 && remainder < 1) {
@@ -40,8 +40,11 @@ const evenThenOddOrderingKey = (n) => {
     }
 };
 
-const styles = (theme) => ({
-    table: {
+/**
+ * @param {import('@mui/material/styles').Theme} theme Theme from ThemeProvider
+ */
+const stylesVirtualizedTable = (theme) => ({
+    '& .table': {
         // temporary right-to-left patch, waiting for
         // https://github.com/bvaughn/react-virtualized/issues/454
         '& .ReactVirtualized__Table__headerRow': {
@@ -50,41 +53,45 @@ const styles = (theme) => ({
                 theme.direction === 'rtl' ? '0 !important' : undefined,
         },
     },
-    tableRow: {
+    '& .tableRow': {
         cursor: 'pointer',
     },
-    tableRowHover: {
+    '& .tableRowHover': {
         '&:hover': {
             backgroundColor: theme.palette.info.light,
         },
     },
-    tableCell: {
+    '& .tableCell': {
         flex: 1,
         padding: DEFAULT_CELL_PADDING + 'px',
     },
-    noClick: {
+    '& .noClick': {
         cursor: 'initial',
     },
-    tableCellColor: {
+    '& .tableCellColor': {
         color: theme.palette.primary.contrastText,
     },
-    header: {
+    '& .header': {
         backgroundColor: theme.palette.info.light,
         color: theme.palette.primary.contrastText,
         fontWeight: 'bold',
     },
-    rowBackgroundDark: {
+    '& .rowBackgroundDark': {
         backgroundColor: theme.palette.info.dark,
     },
-    rowBackgroundLight: {
+    '& .rowBackgroundLight': {
         backgroundColor: theme.palette.info.main,
     },
 });
-
-const StyledVirtualizedTableJss = withStyles(styles)(MuiVirtualizedTable);
+const StyledVirtualizedTableJss = styled(MuiVirtualizedTable)(
+    stylesVirtualizedTable
+);
 
 const stylesEmotion = ({ theme }) =>
-    toNestedGlobalSelectors(styles(theme), generateMuiVirtualizedTableClass);
+    toNestedGlobalSelectors(
+        stylesVirtualizedTable(theme),
+        generateMuiVirtualizedTableClass
+    );
 const StyledVirtualizedTableEmotion =
     styled(MuiVirtualizedTable)(stylesEmotion);
 

--- a/demo/src/TableTab.jsx
+++ b/demo/src/TableTab.jsx
@@ -14,7 +14,7 @@ import {
     Switch,
     TextField,
 } from '@mui/material';
-import { styled, withStyles } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import { DEFAULT_CELL_PADDING, KeyedColumnsRowIndexer } from '../../src';
 import MuiVirtualizedTable, {
     generateMuiVirtualizedTableClass,
@@ -83,27 +83,15 @@ const stylesVirtualizedTable = (theme) => ({
         backgroundColor: theme.palette.info.main,
     },
 });
-const StyledVirtualizedTableJss = styled(MuiVirtualizedTable)(
-    stylesVirtualizedTable
-);
-
 const stylesEmotion = ({ theme }) =>
     toNestedGlobalSelectors(
         stylesVirtualizedTable(theme),
         generateMuiVirtualizedTableClass
     );
-const StyledVirtualizedTableEmotion =
-    styled(MuiVirtualizedTable)(stylesEmotion);
+const StyledVirtualizedTable = styled(MuiVirtualizedTable)(stylesEmotion);
 
-export const TableTab = ({ stylesProvider }) => {
+export const TableTab = () => {
     const [usesCustomStyles, setUsesCustomStyles] = useState(true);
-
-    const StyledVirtualizedTable =
-        stylesProvider === 'emotion'
-            ? StyledVirtualizedTableEmotion
-            : stylesProvider === 'jss'
-            ? StyledVirtualizedTableJss
-            : undefined;
 
     const VirtualizedTable = usesCustomStyles
         ? StyledVirtualizedTable
@@ -234,7 +222,7 @@ export const TableTab = ({ stylesProvider }) => {
         return (
             <Stack sx={{ margin: '1ex' }}>
                 {mkSwitch(
-                    'Custom theme (' + stylesProvider + ')',
+                    'Custom theme (emotion)',
                     usesCustomStyles,
                     setUsesCustomStyles
                 )}

--- a/demo/src/app.jsx
+++ b/demo/src/app.jsx
@@ -31,20 +31,16 @@ import {
     Checkbox,
     createTheme,
     CssBaseline,
-    FormControl,
     FormControlLabel,
     FormGroup,
     Grid,
-    InputLabel,
-    MenuItem,
-    Select,
     Tab,
     Tabs,
     TextField,
     ThemeProvider,
     Typography,
 } from '@mui/material';
-import { makeStyles, styled, withStyles } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import { StyledEngineProvider } from '@mui/styled-engine';
 
 import { useMatch } from 'react-router';
@@ -170,16 +166,12 @@ const TreeViewFinderCustomStyles = (theme) => ({
         marginRight: theme.spacing(1),
     },
 });
-const CustomTreeViewFinderJss = styled(TreeViewFinder)(
-    TreeViewFinderCustomStyles
-);
-
 const TreeViewFinderCustomStylesEmotion = ({ theme }) =>
     toNestedGlobalSelectors(
         TreeViewFinderCustomStyles(theme),
         generateTreeViewFinderClass
     );
-const CustomTreeViewFinderEmotion = styled(TreeViewFinder)(
+const CustomTreeViewFinder = styled(TreeViewFinder)(
     TreeViewFinderCustomStylesEmotion
 );
 
@@ -273,7 +265,6 @@ const AppContent = ({ language, onLanguageClick }) => {
     ] = useState(false);
 
     const [theme, setTheme] = useState(LIGHT_THEME);
-    const [stylesProvider, setStylesProvider] = useState('emotion');
 
     const [tabIndex, setTabIndex] = useState(0);
 
@@ -531,13 +522,6 @@ const AppContent = ({ language, onLanguageClick }) => {
         );
     }
 
-    const CustomTreeViewFinder =
-        stylesProvider === 'emotion'
-            ? CustomTreeViewFinderEmotion
-            : stylesProvider === 'jss'
-            ? CustomTreeViewFinderJss
-            : undefined;
-
     const defaultTab = (
         <div>
             <Box mt={3}>
@@ -655,7 +639,7 @@ const AppContent = ({ language, onLanguageClick }) => {
                         setOpenTreeViewFinderDialogCustomDialog(true)
                     }
                 >
-                    Open Custom TreeViewFinder ({stylesProvider}) ...
+                    Open Custom TreeViewFinder (emotion) ...
                 </Button>
                 <CustomTreeViewFinder
                     open={openTreeViewFinderDialogCustomDialog}
@@ -780,11 +764,7 @@ const AppContent = ({ language, onLanguageClick }) => {
                             elementsFound={equipmentsFound}
                             renderElement={(props) => (
                                 <EquipmentItem
-                                    styles={
-                                        stylesProvider === 'emotion'
-                                            ? equipmentStyles
-                                            : undefined
-                                    }
+                                    styles={equipmentStyles}
                                     {...props}
                                     key={props.element.key}
                                 />
@@ -806,30 +786,6 @@ const AppContent = ({ language, onLanguageClick }) => {
                             </div>
                             <div style={{ flexGrow: 1 }} />
                             <div style={{ alignSelf: 'center' }}>baz</div>
-                            <FormControl
-                                sx={{ m: 1, minWidth: 120 }}
-                                size="small"
-                            >
-                                <InputLabel id="styles-provider-label">
-                                    {intl.formatMessage({
-                                        id: 'top-bar/customTheme',
-                                    })}
-                                </InputLabel>
-                                <Select
-                                    labelId="styles-provider-label"
-                                    id="styles-provider"
-                                    value={stylesProvider}
-                                    label="Styles Provider"
-                                    onChange={(e) =>
-                                        setStylesProvider(e.target.value)
-                                    }
-                                >
-                                    <MenuItem value={'emotion'}>
-                                        emotion
-                                    </MenuItem>
-                                    <MenuItem value={'jss'}>jss</MenuItem>
-                                </Select>
-                            </FormControl>
                         </TopBar>
                         <CardErrorBoundary>
                             {user !== null ? (
@@ -846,11 +802,7 @@ const AppContent = ({ language, onLanguageClick }) => {
                                         <Tab label="inputs" />
                                     </Tabs>
                                     {tabIndex === 0 && defaultTab}
-                                    {tabIndex === 1 && (
-                                        <TableTab
-                                            stylesProvider={stylesProvider}
-                                        />
-                                    )}
+                                    {tabIndex === 1 && <TableTab />}
                                     {tabIndex === 2 && <FlatParametersTab />}
                                     {tabIndex === 3 && <InputsTab />}
                                 </div>

--- a/demo/src/app.jsx
+++ b/demo/src/app.jsx
@@ -157,20 +157,21 @@ const getMuiTheme = (theme) => {
     }
 };
 
-const useEquipmentStyles = makeStyles(equipmentStyles);
-
+/**
+ * @param {import('@mui/material/styles').Theme} theme Theme from ThemeProvider
+ */
 const TreeViewFinderCustomStyles = (theme) => ({
-    icon: {
+    '& .icon': {
         width: '32px',
         height: '32px',
     },
-    labelIcon: {
+    '& .labelIcon': {
         backgroundColor: 'green',
         marginRight: theme.spacing(1),
     },
 });
-const CustomTreeViewFinderJss = withStyles(TreeViewFinderCustomStyles)(
-    TreeViewFinder
+const CustomTreeViewFinderJss = styled(TreeViewFinder)(
+    TreeViewFinderCustomStyles
 );
 
 const TreeViewFinderCustomStylesEmotion = ({ theme }) =>
@@ -258,7 +259,6 @@ const AppContent = ({ language, onLanguageClick }) => {
     const navigate = useNavigate();
     const location = useLocation();
     const intl = useIntl();
-    const equipmentClasses = useEquipmentStyles();
     const [searchDisabled, setSearchDisabled] = useState(false);
     const [userManager, setUserManager] = useState({
         instance: null,
@@ -780,11 +780,6 @@ const AppContent = ({ language, onLanguageClick }) => {
                             elementsFound={equipmentsFound}
                             renderElement={(props) => (
                                 <EquipmentItem
-                                    classes={
-                                        stylesProvider === 'jss'
-                                            ? equipmentClasses
-                                            : undefined
-                                    }
                                     styles={
                                         stylesProvider === 'emotion'
                                             ? equipmentStyles

--- a/src/components/translations/top-bar-en.js
+++ b/src/components/translations/top-bar-en.js
@@ -16,7 +16,6 @@ const top_bar_en = {
     'top-bar/id': 'Id',
     'top-bar/name': 'Name',
     'top-bar/language': 'Language',
-    'top-bar/customTheme': 'Custom theme',
 
     'about-dialog/title': 'About',
     'about-dialog/version': 'Version {version}',

--- a/src/components/translations/top-bar-fr.js
+++ b/src/components/translations/top-bar-fr.js
@@ -16,7 +16,6 @@ const top_bar_fr = {
     'top-bar/id': 'Id',
     'top-bar/name': 'Nom',
     'top-bar/language': 'Langue',
-    'top-bar/customTheme': 'Choix de theme',
 
     'about-dialog/title': 'À propos',
     'about-dialog/version': 'Version {version}',

--- a/src/utils/EquipmentType.js
+++ b/src/utils/EquipmentType.js
@@ -24,7 +24,11 @@ export const equipmentStyles = {
         padding: '4px',
         fontSize: 'x-small',
         textAlign: 'center',
-        color: theme === LIGHT_THEME ? 'inherit' : 'black',
+        color:
+            //TODO remove first condition when gridstudy is updated
+            theme === LIGHT_THEME || theme?.palette?.mode === 'light'
+                ? 'inherit'
+                : 'black',
     }),
     equipmentTypeTag: {
         minWidth: TYPE_TAG_MAX_SIZE,


### PR DESCRIPTION
Splitted part of #350

---

the old JSS system is only used in the demo with `TableTab` and `EquipementItem` components
  * `EquipementItem` doesn't depend explicitly to JSS
    * only used by GridStudy and only used emotion system
      EDIT: has been said it was to compare the visual of components before migrating to emotion

Used [migration guide](https://mui.com/material-ui/migration/migrating-from-jss/) with the help of [`@mui/codemod`](https://github.com/mui/material-ui/blob/master/packages/mui-codemod/README.md#jss-to-styled).