### PR TITLE
Remove React imports 

### DIFF
--- a/demo/data/TreeViewFinder.jsx
+++ b/demo/data/TreeViewFinder.jsx
@@ -4,9 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React from 'react';
 
-/* Icons for customization*/
 import {
     AcUnit as AcUnitIcon,
     Coronavirus as CoronavirusIcon,

--- a/demo/src/FlatParametersTab.jsx
+++ b/demo/src/FlatParametersTab.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import RightResizableBox from './right-resizable-box';
 import FlatParameters from '../../src/components/FlatParameters/FlatParameters';
 

--- a/demo/src/InputsTab.jsx
+++ b/demo/src/InputsTab.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { FormProvider, useForm } from 'react-hook-form';

--- a/demo/src/TableTab.jsx
+++ b/demo/src/TableTab.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { DEFAULT_CELL_PADDING, KeyedColumnsRowIndexer } from '../../src';
 import { styled } from '@mui/system';
 import { withStyles } from '@mui/styles';

--- a/demo/src/TreeViewFinderConfig.jsx
+++ b/demo/src/TreeViewFinderConfig.jsx
@@ -4,7 +4,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React from 'react';
 
 import {
     Checkbox,
@@ -17,7 +16,7 @@ import {
 } from '@mui/material';
 
 /**
- * TreeViewFinderConfig documentation :
+ * TreeViewFinderConfig documentation:
  * Component to configure TreeViewFinder for demo
  *
 

--- a/demo/src/app.jsx
+++ b/demo/src/app.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import TopBar from '../../src/components/TopBar';
 import SnackbarProvider from '../../src/components/SnackbarProvider';
@@ -280,13 +280,13 @@ const AppContent = ({ language, onLanguageClick }) => {
 
     const [equipmentLabelling, setEquipmentLabelling] = useState(false);
 
-    const [openReportViewer, setOpenReportViewer] = React.useState(false);
+    const [openReportViewer, setOpenReportViewer] = useState(false);
     const [openTreeViewFinderDialog, setOpenTreeViewFinderDialog] =
-        React.useState(false);
+        useState(false);
     const [
         openTreeViewFinderDialogCustomDialog,
         setOpenTreeViewFinderDialogCustomDialog,
-    ] = React.useState(false);
+    ] = useState(false);
 
     // Can't use lazy initializer because useMatch is a hook
     const [initialMatchSilentRenewCallbackUrl] = useState(

--- a/demo/src/right-resizable-box.jsx
+++ b/demo/src/right-resizable-box.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { MoreVert as ResizePanelHandleIcon } from '@mui/icons-material';
 import { ResizableBox } from 'react-resizable';
 import { useWindowWidth } from '@react-hook/window-size';

--- a/src/components/AuthenticationRouter/AuthenticationRouter.jsx
+++ b/src/components/AuthenticationRouter/AuthenticationRouter.jsx
@@ -61,9 +61,7 @@ const AuthenticationRouter = ({
                     element={
                         <SignInCallbackHandler
                             userManager={userManager.instance}
-                            handleSignInCallback={
-                                handleSigninCallbackClosure
-                            }
+                            handleSignInCallback={handleSigninCallbackClosure}
                         />
                     }
                 />
@@ -78,10 +76,7 @@ const AuthenticationRouter = ({
                         />
                     }
                 />
-                <Route
-                    path="logout-callback"
-                    element={<Navigate to="/" />}
-                />
+                <Route path="logout-callback" element={<Navigate to="/" />} />
                 <Route
                     path="*"
                     element={
@@ -123,8 +118,8 @@ const AuthenticationRouter = ({
                                 />
                                 <p>
                                     {
-                                        authenticationRouterError
-                                            .logoutError.error.message
+                                        authenticationRouterError.logoutError
+                                            .error.message
                                     }
                                 </p>
                             </Alert>
@@ -145,8 +140,7 @@ const AuthenticationRouter = ({
                                 <p>
                                     {
                                         authenticationRouterError
-                                            .userValidationError.error
-                                            .message
+                                            .userValidationError.error.message
                                     }
                                 </p>
                             </Alert>

--- a/src/components/AuthenticationRouter/AuthenticationRouter.jsx
+++ b/src/components/AuthenticationRouter/AuthenticationRouter.jsx
@@ -40,138 +40,136 @@ const AuthenticationRouter = ({
     );
 
     return (
-        <React.Fragment>
-            <Grid
-                container
-                alignContent={'center'}
-                alignItems={'center'}
-                direction={'column'}
-            >
-                {userManager.error !== null && (
-                    <h1>Error : Getting userManager; {userManager.error}</h1>
-                )}
-                {signInCallbackError !== null && (
-                    <h1>
-                        Error : SignIn Callback Error;
-                        {signInCallbackError.message}
-                    </h1>
-                )}
-                <Routes>
-                    <Route
-                        path="sign-in-callback"
-                        element={
-                            <SignInCallbackHandler
-                                userManager={userManager.instance}
-                                handleSignInCallback={
-                                    handleSigninCallbackClosure
-                                }
-                            />
-                        }
-                    />
-                    <Route
-                        path="silent-renew-callback"
-                        element={
-                            <SilentRenewCallbackHandler
-                                userManager={userManager.instance}
-                                handleSilentRenewCallback={
-                                    handleSilentRenewCallbackClosure
-                                }
-                            />
-                        }
-                    />
-                    <Route
-                        path="logout-callback"
-                        element={<Navigate to="/" />}
-                    />
-                    <Route
-                        path="*"
-                        element={
-                            showAuthenticationRouterLogin &&
-                            authenticationRouterError == null && (
-                                <Login
-                                    disabled={userManager.instance === null}
-                                    onLoginClick={() =>
-                                        login(location, userManager.instance)
-                                    }
-                                />
-                            )
-                        }
-                    />
-                </Routes>
-
-                {authenticationRouterError !== null && (
-                    <>
-                        <Grid item>
-                            <Logout
+        <Grid
+            container
+            alignContent={'center'}
+            alignItems={'center'}
+            direction={'column'}
+        >
+            {userManager.error !== null && (
+                <h1>Error : Getting userManager; {userManager.error}</h1>
+            )}
+            {signInCallbackError !== null && (
+                <h1>
+                    Error : SignIn Callback Error;
+                    {signInCallbackError.message}
+                </h1>
+            )}
+            <Routes>
+                <Route
+                    path="sign-in-callback"
+                    element={
+                        <SignInCallbackHandler
+                            userManager={userManager.instance}
+                            handleSignInCallback={
+                                handleSigninCallbackClosure
+                            }
+                        />
+                    }
+                />
+                <Route
+                    path="silent-renew-callback"
+                    element={
+                        <SilentRenewCallbackHandler
+                            userManager={userManager.instance}
+                            handleSilentRenewCallback={
+                                handleSilentRenewCallbackClosure
+                            }
+                        />
+                    }
+                />
+                <Route
+                    path="logout-callback"
+                    element={<Navigate to="/" />}
+                />
+                <Route
+                    path="*"
+                    element={
+                        showAuthenticationRouterLogin &&
+                        authenticationRouterError == null && (
+                            <Login
                                 disabled={userManager.instance === null}
-                                onLogoutClick={() =>
-                                    logout(location, userManager.instance)
+                                onLoginClick={() =>
+                                    login(location, userManager.instance)
                                 }
                             />
-                        </Grid>
-                        <Grid item xs={4}>
-                            {authenticationRouterError.logoutError != null && (
-                                <Alert severity="error">
-                                    <AlertTitle>
-                                        <FormattedMessage id="login/errorInLogout" />
-                                    </AlertTitle>
-                                    <FormattedMessage
-                                        id="login/errorInLogoutMessage"
-                                        values={{
-                                            userName:
-                                                authenticationRouterError.userName,
-                                        }}
-                                    />
-                                    <p>
-                                        {
-                                            authenticationRouterError
-                                                .logoutError.error.message
-                                        }
-                                    </p>
-                                </Alert>
-                            )}
-                            {authenticationRouterError?.userValidationError !=
-                                null && (
-                                <Alert severity="error">
-                                    <AlertTitle>
-                                        <FormattedMessage id="login/errorInUserValidation" />
-                                    </AlertTitle>
-                                    <FormattedMessage
-                                        id="login/errorInUserValidationMessage"
-                                        values={{
-                                            userName:
-                                                authenticationRouterError.userName,
-                                        }}
-                                    />
-                                    <p>
-                                        {
-                                            authenticationRouterError
-                                                .userValidationError.error
-                                                .message
-                                        }
-                                    </p>
-                                </Alert>
-                            )}
-                            {authenticationRouterError?.unauthorizedUserInfo !=
-                                null && (
-                                <Alert severity="info">
-                                    <AlertTitle>
-                                        <FormattedMessage id="login/unauthorizedAccess" />
-                                    </AlertTitle>
-                                    <FormattedMessage
-                                        id="login/unauthorizedAccessMessage"
-                                        values={{
-                                            userName:
-                                                authenticationRouterError.userName,
-                                        }}
-                                    />
-                                </Alert>
-                            )}
-                        </Grid>
-                    </>
-                )}
-            </Grid>
-        </React.Fragment>
+                        )
+                    }
+                />
+            </Routes>
+
+            {authenticationRouterError !== null && (
+                <>
+                    <Grid item>
+                        <Logout
+                            disabled={userManager.instance === null}
+                            onLogoutClick={() =>
+                                logout(location, userManager.instance)
+                            }
+                        />
+                    </Grid>
+                    <Grid item xs={4}>
+                        {authenticationRouterError.logoutError != null && (
+                            <Alert severity="error">
+                                <AlertTitle>
+                                    <FormattedMessage id="login/errorInLogout" />
+                                </AlertTitle>
+                                <FormattedMessage
+                                    id="login/errorInLogoutMessage"
+                                    values={{
+                                        userName:
+                                            authenticationRouterError.userName,
+                                    }}
+                                />
+                                <p>
+                                    {
+                                        authenticationRouterError
+                                            .logoutError.error.message
+                                    }
+                                </p>
+                            </Alert>
+                        )}
+                        {authenticationRouterError?.userValidationError !=
+                            null && (
+                            <Alert severity="error">
+                                <AlertTitle>
+                                    <FormattedMessage id="login/errorInUserValidation" />
+                                </AlertTitle>
+                                <FormattedMessage
+                                    id="login/errorInUserValidationMessage"
+                                    values={{
+                                        userName:
+                                            authenticationRouterError.userName,
+                                    }}
+                                />
+                                <p>
+                                    {
+                                        authenticationRouterError
+                                            .userValidationError.error
+                                            .message
+                                    }
+                                </p>
+                            </Alert>
+                        )}
+                        {authenticationRouterError?.unauthorizedUserInfo !=
+                            null && (
+                            <Alert severity="info">
+                                <AlertTitle>
+                                    <FormattedMessage id="login/unauthorizedAccess" />
+                                </AlertTitle>
+                                <FormattedMessage
+                                    id="login/unauthorizedAccessMessage"
+                                    values={{
+                                        userName:
+                                            authenticationRouterError.userName,
+                                    }}
+                                />
+                            </Alert>
+                        )}
+                    </Grid>
+                </>
+            )}
+        </Grid>
     );
 };
 export default AuthenticationRouter;

--- a/src/components/AuthenticationRouter/AuthenticationRouter.jsx
+++ b/src/components/AuthenticationRouter/AuthenticationRouter.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import SignInCallbackHandler from '../SignInCallbackHandler';
 import {

--- a/src/components/CardErrorBoundary/card-error-boundary.jsx
+++ b/src/components/CardErrorBoundary/card-error-boundary.jsx
@@ -9,7 +9,7 @@
 //    https://reactjs.org/docs/error-boundaries.html
 //    https://mui.com/material-ui/react-card/#complex-interaction
 
-import React from 'react';
+import { Component } from 'react';
 import {
     Box,
     Card,
@@ -38,7 +38,7 @@ const ExpandMore = styled((props) => {
     }),
 }));
 
-class CardErrorBoundary extends React.Component {
+class CardErrorBoundary extends Component {
     constructor(props) {
         super(props);
         this.state = {

--- a/src/components/ElementSearchDialog/element-search-dialog.jsx
+++ b/src/components/ElementSearchDialog/element-search-dialog.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
 import { Autocomplete, Dialog, DialogContent, TextField } from '@mui/material';
 import PropTypes from 'prop-types';
 import { Search, SearchOff } from '@mui/icons-material';
@@ -133,14 +133,14 @@ const ElementSearchDialog = (props) => {
                             InputProps={{
                                 ...params.InputProps,
                                 startAdornment: (
-                                    <React.Fragment>
+                                    <Fragment>
                                         {searchTermDisabled ? (
                                             <SearchOff color="disabled" />
                                         ) : (
                                             <Search color="disabled" />
                                         )}
                                         {params.InputProps.startAdornment}
-                                    </React.Fragment>
+                                    </Fragment>
                                 ),
                             }}
                         />

--- a/src/components/ElementSearchDialog/element-search-dialog.jsx
+++ b/src/components/ElementSearchDialog/element-search-dialog.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Fragment, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Autocomplete, Dialog, DialogContent, TextField } from '@mui/material';
 import PropTypes from 'prop-types';
 import { Search, SearchOff } from '@mui/icons-material';
@@ -133,14 +133,14 @@ const ElementSearchDialog = (props) => {
                             InputProps={{
                                 ...params.InputProps,
                                 startAdornment: (
-                                    <Fragment>
+                                    <>
                                         {searchTermDisabled ? (
                                             <SearchOff color="disabled" />
                                         ) : (
                                             <Search color="disabled" />
                                         )}
                                         {params.InputProps.startAdornment}
-                                    </Fragment>
+                                    </>
                                 ),
                             }}
                         />

--- a/src/components/ElementSearchDialog/equipment-item.jsx
+++ b/src/components/ElementSearchDialog/equipment-item.jsx
@@ -10,7 +10,6 @@ import parse from 'autosuggest-highlight/parse';
 import clsx from 'clsx';
 import { FormattedMessage } from 'react-intl';
 import OverflowableText from '../OverflowableText';
-import React from 'react';
 import { EQUIPMENT_TYPE } from '../../utils/EquipmentType';
 import { Box } from '@mui/material';
 import { mergeSx } from '../../utils/styles';

--- a/src/components/ElementSearchDialog/tag-renderer.jsx
+++ b/src/components/ElementSearchDialog/tag-renderer.jsx
@@ -6,7 +6,6 @@
  */
 import OverflowableText from '../OverflowableText';
 import clsx from 'clsx';
-import React from 'react';
 import { EQUIPMENT_TYPE } from '../../utils/EquipmentType';
 import PropTypes from 'prop-types';
 import { mergeSx } from '../../utils/styles';

--- a/src/components/FlatParameters/FlatParameters.jsx
+++ b/src/components/FlatParameters/FlatParameters.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback, useState } from 'react';
+import { Fragment, useCallback, useState } from 'react';
 import {
     Autocomplete,
     Chip,
@@ -449,7 +449,7 @@ export const FlatParameters = ({
     return (
         <List sx={styles.paramList}>
             {paramsAsArray.map((param, index) => (
-                <React.Fragment key={param.name}>
+                <Fragment key={param.name}>
                     <ListItem sx={styles.paramListItem}>
                         <Tooltip
                             title={
@@ -475,7 +475,7 @@ export const FlatParameters = ({
                     {showSeparator && index !== paramsAsArray.length - 1 && (
                         <Divider />
                     )}
-                </React.Fragment>
+                </Fragment>
             ))}
         </List>
     );

--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import {
     Avatar,
     Box,

--- a/src/components/Login/Logout.jsx
+++ b/src/components/Login/Logout.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import {
     Avatar,
     Box,

--- a/src/components/MuiVirtualizedTable/ColumnHeader.jsx
+++ b/src/components/MuiVirtualizedTable/ColumnHeader.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useRef } from 'react';
+import { forwardRef, useCallback, useMemo, useRef, useState } from 'react';
 
 import {
     ArrowDownward as ArrowDownwardIcon,
@@ -92,7 +92,7 @@ const FilterButton = (props) => {
     );
 };
 
-export const ColumnHeader = React.forwardRef((props, ref) => {
+export const ColumnHeader = forwardRef((props, ref) => {
     const {
         className,
         label,
@@ -105,14 +105,14 @@ export const ColumnHeader = React.forwardRef((props, ref) => {
         style,
     } = props;
 
-    const [hovered, setHovered] = React.useState();
-    const onHover = React.useCallback((evt) => {
+    const [hovered, setHovered] = useState();
+    const onHover = useCallback((evt) => {
         setHovered(evt.type === 'mouseenter');
     }, []);
 
     const topmostDiv = useRef();
 
-    const handleFilterClick = React.useMemo(() => {
+    const handleFilterClick = useMemo(() => {
         if (!onFilterClick) {
             return undefined;
         }

--- a/src/components/MuiVirtualizedTable/MuiVirtualizedTable.jsx
+++ b/src/components/MuiVirtualizedTable/MuiVirtualizedTable.jsx
@@ -8,7 +8,7 @@
 /**
  * This class has been taken from 'Virtualized Table' example at https://material-ui.com/components/tables/
  */
-import React, { createRef } from 'react';
+import { createRef, PureComponent } from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
@@ -251,7 +251,7 @@ const reorderIndex = memoize(
     }
 );
 
-class MuiVirtualizedTable extends React.PureComponent {
+class MuiVirtualizedTable extends PureComponent {
     static defaultProps = {
         headerHeight: DEFAULT_HEADER_HEIGHT,
         rowHeight: DEFAULT_ROW_HEIGHT,

--- a/src/components/MultipleSelectionDialog/MultipleSelectionDialog.jsx
+++ b/src/components/MultipleSelectionDialog/MultipleSelectionDialog.jsx
@@ -17,7 +17,7 @@ import {
     List,
 } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
-import React, { useState } from 'react';
+import { Fragment, useState } from 'react';
 
 const MultipleSelectionDialog = ({
     options,
@@ -78,7 +78,7 @@ const MultipleSelectionDialog = ({
                                 const optionId = option?.id ?? option;
                                 const label = getOptionLabel(option);
                                 return (
-                                    <React.Fragment key={optionId}>
+                                    <Fragment key={optionId}>
                                         <Grid item>
                                             <FormControlLabel
                                                 label={label}
@@ -96,7 +96,7 @@ const MultipleSelectionDialog = ({
                                                 }
                                             />
                                         </Grid>
-                                    </React.Fragment>
+                                    </Fragment>
                                 );
                             })}
                         </List>

--- a/src/components/MultipleSelectionDialog/MultipleSelectionDialog.jsx
+++ b/src/components/MultipleSelectionDialog/MultipleSelectionDialog.jsx
@@ -17,7 +17,7 @@ import {
     List,
 } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
-import { Fragment, useState } from 'react';
+import { useState } from 'react';
 
 const MultipleSelectionDialog = ({
     options,
@@ -41,7 +41,6 @@ const MultipleSelectionDialog = ({
             if (oldValues.includes(option)) {
                 return oldValues.filter((o) => o !== option);
             }
-
             return [...oldValues, option];
         });
     };
@@ -78,25 +77,23 @@ const MultipleSelectionDialog = ({
                                 const optionId = option?.id ?? option;
                                 const label = getOptionLabel(option);
                                 return (
-                                    <Fragment key={optionId}>
-                                        <Grid item>
-                                            <FormControlLabel
-                                                label={label}
-                                                control={
-                                                    <Checkbox
-                                                        checked={selectedIds.includes(
+                                    <Grid item key={optionId}>
+                                        <FormControlLabel
+                                            label={label}
+                                            control={
+                                                <Checkbox
+                                                    checked={selectedIds.includes(
+                                                        optionId
+                                                    )}
+                                                    onChange={() =>
+                                                        handleOptionSelection(
                                                             optionId
-                                                        )}
-                                                        onChange={() =>
-                                                            handleOptionSelection(
-                                                                optionId
-                                                            )
-                                                        }
-                                                    />
-                                                }
-                                            />
-                                        </Grid>
-                                    </Fragment>
+                                                        )
+                                                    }
+                                                />
+                                            }
+                                        />
+                                    </Grid>
                                 );
                             })}
                         </List>

--- a/src/components/OverflowableText/overflowable-text.jsx
+++ b/src/components/OverflowableText/overflowable-text.jsx
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { Box, Tooltip } from '@mui/material';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/system';

--- a/src/components/ReportViewer/filter-button.jsx
+++ b/src/components/ReportViewer/filter-button.jsx
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Box, IconButton } from '@mui/material';
 import { Menu as MenuIcon } from '@mui/icons-material';
 import { MultiSelectList } from './multi-select-list';

--- a/src/components/ReportViewer/log-table.jsx
+++ b/src/components/ReportViewer/log-table.jsx
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React, { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { TableCell, useTheme } from '@mui/material';
 import { styled } from '@mui/system';

--- a/src/components/ReportViewer/multi-select-list.jsx
+++ b/src/components/ReportViewer/multi-select-list.jsx
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React from 'react';
+
 import { Checkbox, FormControlLabel, Menu, MenuItem } from '@mui/material';
 
 const styles = {

--- a/src/components/ReportViewer/report-item.jsx
+++ b/src/components/ReportViewer/report-item.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Box, Typography } from '@mui/material';
 import { alpha, styled } from '@mui/system';
 import PropTypes from 'prop-types';

--- a/src/components/ReportViewer/report-viewer.jsx
+++ b/src/components/ReportViewer/report-viewer.jsx
@@ -5,13 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import {
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { TreeView } from '@mui/lab';
 import {
     ArrowDropDown as ArrowDropDownIcon,

--- a/src/components/ReportViewer/report-viewer.jsx
+++ b/src/components/ReportViewer/report-viewer.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, {
+import {
     useCallback,
     useEffect,
     useMemo,

--- a/src/components/ReportViewerDialog/report-viewer-dialog.jsx
+++ b/src/components/ReportViewerDialog/report-viewer-dialog.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
     Button,
     Dialog,

--- a/src/components/SignInCallbackHandler/SignInCallbackHandler.jsx
+++ b/src/components/SignInCallbackHandler/SignInCallbackHandler.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 const SignInCallbackHandler = ({ userManager, handleSignInCallback }) => {
     useEffect(() => {

--- a/src/components/SilentRenewCallbackHandler/SilentRenewCallbackHandler.jsx
+++ b/src/components/SilentRenewCallbackHandler/SilentRenewCallbackHandler.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 const SilentRenewCallbackHandler = ({
     userManager,

--- a/src/components/SnackbarProvider/SnackbarProvider.jsx
+++ b/src/components/SnackbarProvider/SnackbarProvider.jsx
@@ -5,13 +5,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useRef } from 'react';
+import { forwardRef, useRef } from 'react';
 import { Button } from '@mui/material';
 
 import { SnackbarProvider as OrigSnackbarProvider } from 'notistack';
 
 /* A wrapper around notistack's SnackbarProvider that provides defaults props */
-const SnackbarProvider = React.forwardRef((props, ref) => {
+const SnackbarProvider = forwardRef((props, ref) => {
     // create our own ref and use it if the parent
     // did not create a ref for us.
     const innerRef = useRef();

--- a/src/components/TopBar/AboutDialog.jsx
+++ b/src/components/TopBar/AboutDialog.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
     Accordion,
     AccordionDetails,

--- a/src/components/TopBar/GridLogo.jsx
+++ b/src/components/TopBar/GridLogo.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import { Box, Typography } from '@mui/material';
 import { BrokenImage } from '@mui/icons-material';
 import { mergeSx } from '../../utils/styles';

--- a/src/components/TopBar/TopBar.jsx
+++ b/src/components/TopBar/TopBar.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import {
@@ -174,9 +174,8 @@ const TopBar = ({
     onLanguageClick,
     language,
 }) => {
-    const [anchorElSettingsMenu, setAnchorElSettingsMenu] =
-        React.useState(null);
-    const [anchorElAppsMenu, setAnchorElAppsMenu] = React.useState(null);
+    const [anchorElSettingsMenu, setAnchorElSettingsMenu] = useState(null);
+    const [anchorElAppsMenu, setAnchorElAppsMenu] = useState(null);
     const fullScreenRef = useRef(null);
     const [isFullScreen, setIsFullScreen] = useState(false);
 

--- a/src/components/TreeViewFinder/TreeViewFinder.jsx
+++ b/src/components/TreeViewFinder/TreeViewFinder.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import {

--- a/src/components/react-hook-form/autocomplete-input.jsx
+++ b/src/components/react-hook-form/autocomplete-input.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Autocomplete, TextField } from '@mui/material';
 import { useController, useFormContext } from 'react-hook-form';

--- a/src/components/react-hook-form/booleans/boolean-input.jsx
+++ b/src/components/react-hook-form/booleans/boolean-input.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { FormControlLabel } from '@mui/material';

--- a/src/components/react-hook-form/booleans/checkbox-input.jsx
+++ b/src/components/react-hook-form/booleans/checkbox-input.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import PropTypes from 'prop-types';
 import BooleanInput from './boolean-input';
 import { Checkbox } from '@mui/material';

--- a/src/components/react-hook-form/booleans/switch-input.jsx
+++ b/src/components/react-hook-form/booleans/switch-input.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import PropTypes from 'prop-types';
 import BooleanInput from './boolean-input';
 import { Switch } from '@mui/material';

--- a/src/components/react-hook-form/directory-items-input.tsx
+++ b/src/components/react-hook-form/directory-items-input.tsx
@@ -10,12 +10,7 @@ import OverflowableText from '../OverflowableText';
 import { useSnackMessage } from '../../hooks/useSnackMessage';
 import FieldLabel from './utils/field-label';
 import FolderIcon from '@mui/icons-material/Folder';
-import {
-    FunctionComponent,
-    useCallback,
-    useMemo,
-    useState,
-} from 'react';
+import { FunctionComponent, useCallback, useMemo, useState } from 'react';
 import { useController, useFieldArray, useFormContext } from 'react-hook-form';
 import { useIntl } from 'react-intl';
 import ErrorInput from '../react-hook-form/error-management/error-input.jsx';

--- a/src/components/react-hook-form/directory-items-input.tsx
+++ b/src/components/react-hook-form/directory-items-input.tsx
@@ -10,7 +10,7 @@ import OverflowableText from '../OverflowableText';
 import { useSnackMessage } from '../../hooks/useSnackMessage';
 import FieldLabel from './utils/field-label';
 import FolderIcon from '@mui/icons-material/Folder';
-import React, {
+import {
     FunctionComponent,
     useCallback,
     useMemo,

--- a/src/components/react-hook-form/error-management/error-input.jsx
+++ b/src/components/react-hook-form/error-management/error-input.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useController } from 'react-hook-form';
 

--- a/src/components/react-hook-form/error-management/field-error-alert.jsx
+++ b/src/components/react-hook-form/error-management/field-error-alert.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import { Alert, Grid } from '@mui/material';
 
 // component to display alert when a specific rhf field is in error

--- a/src/components/react-hook-form/error-management/mid-form-error.jsx
+++ b/src/components/react-hook-form/error-management/mid-form-error.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import { Box } from '@mui/material';
 
 // component to display error message in the middle of dialog

--- a/src/components/react-hook-form/numbers/float-input.jsx
+++ b/src/components/react-hook-form/numbers/float-input.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import TextInput from '../text-input';
 import { isFloatNumber } from './utils';
 

--- a/src/components/react-hook-form/numbers/integer-input.jsx
+++ b/src/components/react-hook-form/numbers/integer-input.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import TextInput from '../text-input';
 import { isIntegerNumber } from './utils';
 

--- a/src/components/react-hook-form/radio-input.jsx
+++ b/src/components/react-hook-form/radio-input.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import PropTypes from 'prop-types';
 import {
     FormControl,

--- a/src/components/react-hook-form/select-input.jsx
+++ b/src/components/react-hook-form/select-input.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import PropTypes from 'prop-types';
 import AutocompleteInput from './autocomplete-input';
 import { useIntl } from 'react-intl';

--- a/src/components/react-hook-form/slider-input.jsx
+++ b/src/components/react-hook-form/slider-input.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Slider } from '@mui/material';
 import { useController } from 'react-hook-form';

--- a/src/components/react-hook-form/text-input.jsx
+++ b/src/components/react-hook-form/text-input.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import PropTypes from 'prop-types';
 import { IconButton, InputAdornment, TextField } from '@mui/material';
 import { Clear as ClearIcon } from '@mui/icons-material';

--- a/src/components/react-hook-form/utils/cancel-button.jsx
+++ b/src/components/react-hook-form/utils/cancel-button.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import { Button } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';

--- a/src/components/react-hook-form/utils/field-label.jsx
+++ b/src/components/react-hook-form/utils/field-label.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 const FieldLabel = ({ label, optional, values = undefined }) => {

--- a/src/components/react-hook-form/utils/functions.jsx
+++ b/src/components/react-hook-form/utils/functions.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { getIn } from 'yup';
 

--- a/src/components/react-hook-form/utils/submit-button.jsx
+++ b/src/components/react-hook-form/utils/submit-button.jsx
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React from 'react';
 import { Button } from '@mui/material';
 import { useFormState } from 'react-hook-form';
 import { FormattedMessage } from 'react-intl';

--- a/src/components/react-hook-form/utils/text-field-with-adornment.jsx
+++ b/src/components/react-hook-form/utils/text-field-with-adornment.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Clear as ClearIcon } from '@mui/icons-material';
 import { IconButton, InputAdornment, TextField } from '@mui/material';

--- a/src/utils/ElementType.jsx
+++ b/src/utils/ElementType.jsx
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import React from 'react';
+
 import {
     Article as ArticleIcon,
     LibraryBooksOutlined as LibraryBooksOutlinedIcon,


### PR DESCRIPTION
Since React 17, it's [no longer necessary to `import React from 'react'`](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).

[_goodbye-react-imports-17_](https://www.linkedin.com/pulse/say-goodbye-react-imports-17s-game-changing-feature-deepak-sharma-)