### PR TITLE
Activate allowJs and skipLibCheck in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
         "moduleResolution": "bundler",
         "target": "es6",
         "lib": ["dom", "dom.iterable", "esnext"],
+        "allowJs": true,
+        "skipLibCheck": true, // otherwise it checks .d.ts files we import from node_modules and react-request-fullscreen contains an error
         "strict": true,
         "forceConsistentCasingInFileNames": true,
         "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
We activate allowJs to import JS in TS files and also activate skipLibCheck because otherwise TSC check all the .d.ts files, including the ones we import from node_modules, and react-request-fullscreen contains an error