### PR TITLE
Use proper icon for study element

### DIFF
--- a/src/utils/ElementType.jsx
+++ b/src/utils/ElementType.jsx
@@ -38,6 +38,7 @@ export function getFileIcon(type, style) {
         case elementType.VOLTAGE_INIT_PARAMETERS:
         case elementType.SECURITY_ANALYSIS_PARAMETERS:
         case elementType.LOADFLOW_PARAMETERS:
+        case elementType.SENSITIVITY_PARAMETERS:
             return <SettingsIcon sx={style} />;
         case elementType.DIRECTORY:
             // to easily use in TreeView we do not give icons for directories

--- a/src/utils/ElementType.jsx
+++ b/src/utils/ElementType.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import {
     Article as ArticleIcon,
     PhotoLibrary as PhotoLibraryIcon,
+    Photo as PhotoIcon,
     OfflineBolt as OfflineBoltIcon,
     Settings as SettingsIcon,
     NoteAlt as NoteAltIcon,
@@ -16,6 +17,7 @@ import {
 export const elementType = {
     DIRECTORY: 'DIRECTORY',
     STUDY: 'STUDY',
+    CASE: 'CASE',
     FILTER: 'FILTER',
     MODIFICATION: 'MODIFICATION',
     CONTINGENCY_LIST: 'CONTINGENCY_LIST',
@@ -29,6 +31,8 @@ export function getFileIcon(type, style) {
     switch (type) {
         case elementType.STUDY:
             return <PhotoLibraryIcon sx={style} />;
+        case elementType.CASE:
+            return <PhotoIcon sx={style} />;
         case elementType.CONTINGENCY_LIST:
             return <OfflineBoltIcon sx={style} />;
         case elementType.MODIFICATION:

--- a/src/utils/ElementType.jsx
+++ b/src/utils/ElementType.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import {
     Article as ArticleIcon,
-    LibraryBooksOutlined as LibraryBooksOutlinedIcon,
+    PhotoLibrary as PhotoLibraryIcon,
     OfflineBolt as OfflineBoltIcon,
     Settings as SettingsIcon,
     NoteAlt as NoteAltIcon,
@@ -28,7 +28,7 @@ export const elementType = {
 export function getFileIcon(type, style) {
     switch (type) {
         case elementType.STUDY:
-            return <LibraryBooksOutlinedIcon sx={style} />;
+            return <PhotoLibraryIcon sx={style} />;
         case elementType.CONTINGENCY_LIST:
             return <OfflineBoltIcon sx={style} />;
         case elementType.MODIFICATION:


### PR DESCRIPTION
also added CASE element type.

Potential impacts of this MR in grid-explore:
- getElementIcon should/must be deleted and replaced by getFileIcon from commons-ui
- ElementType enum should/must be deleted and replaced by elementType from commons-ui (like it's done in grid-study)