### PR TITLE
Add support for CSS and remove preserveModules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
                 "vite-plugin-dts": "^2.3.0",
                 "vite-plugin-eslint": "^1.8.1",
                 "vite-plugin-externalize-deps": "^0.8.0",
+                "vite-plugin-lib-inject-css": "^2.0.0",
                 "vite-plugin-svgr": "^4.2.0",
                 "yup": "^1.0.0"
             },
@@ -13441,6 +13442,31 @@
             },
             "peerDependencies": {
                 "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+            }
+        },
+        "node_modules/vite-plugin-lib-inject-css": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-lib-inject-css/-/vite-plugin-lib-inject-css-2.0.0.tgz",
+            "integrity": "sha512-5RK9eP2biW340FEbpI8eHZQfeqIz0+Glbkk4U1fZ1QKOvyaYy5K6TmW43KuhmGLizk2Vd4Nv7OwGpxq2wXclyQ==",
+            "dev": true,
+            "dependencies": {
+                "magic-string": "^0.30.7",
+                "picocolors": "^1.0.0"
+            },
+            "peerDependencies": {
+                "vite": "*"
+            }
+        },
+        "node_modules/vite-plugin-lib-inject-css/node_modules/magic-string": {
+            "version": "0.30.8",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+            "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.4.15"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/vite-plugin-svgr": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "files": [
         "dist"
     ],
+    "sideEffects": [
+        "**/*.css"
+    ],
     "scripts": {
         "start": "vite demo/ --config vite.config.mts",
         "start:open": "vite demo/ --config vite.config.mts --open",
@@ -99,6 +102,7 @@
         "vite-plugin-externalize-deps": "^0.8.0",
         "vite-plugin-svgr": "^4.2.0",
         "vite-plugin-dts": "^2.3.0",
+        "vite-plugin-lib-inject-css": "^2.0.0",
         "yup": "^1.0.0"
     },
     "eslintConfig": {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -10,6 +10,7 @@ import type { PluginOption } from 'vite';
 import { defineConfig } from 'vite';
 import eslint from 'vite-plugin-eslint';
 import svgr from 'vite-plugin-svgr';
+import { libInjectCss } from 'vite-plugin-lib-inject-css';
 import dts from 'vite-plugin-dts';
 import { externalizeDeps } from 'vite-plugin-externalize-deps';
 import * as path from 'node:path';
@@ -25,6 +26,7 @@ export default defineConfig({
         }),
         svgr(), // works on every import with the pattern "**/*.svg?react"
         reactVirtualized(),
+        libInjectCss(),
         dts({
             include: ['src'],
         }),
@@ -35,13 +37,12 @@ export default defineConfig({
     build: {
         lib: {
             entry: path.resolve(__dirname, 'src/index.js'),
-            name: 'Commons ui',
             formats: ['es'],
         },
         rollupOptions: {
             output: {
-                preserveModules: true,
-                entryFileNames: '[name].js', // override vite and allow to keep the original tree and .js extension even in ESM
+                assetFileNames: 'assets/[name][extname]',
+                entryFileNames: '[name].js', // override vite and allow to keep .js extension even in ESM
             },
         },
         minify: false, // easier to debug on the apps using this lib


### PR DESCRIPTION
Add support for CSS (auto inject import in js files).
Remove preserveModules option.
https://rollupjs.org/configuration-options/#output-preservemodules
https://github.com/emosheeep/vite-plugin-lib-inject-css/tree/master?tab=readme-ov-file#why-does-style-code-injection-fail