### PR TITLE
Fix DirectoryItemsInputProps interface

### DIFF
--- a/src/components/react-hook-form/directory-items-input.tsx
+++ b/src/components/react-hook-form/directory-items-input.tsx
@@ -68,7 +68,11 @@ interface DirectoryItemsInputProps {
         elementTypes: string[]
     ) => Promise<any>;
     fetchRootFolders: (types: string[]) => Promise<any>;
-    fetchElementsInfos: (ids: UUID[], elementTypes: string[]) => Promise<any>;
+    fetchElementsInfos: (
+        ids: UUID[],
+        elementTypes: string[],
+        equipmentTypes?: string[]
+    ) => Promise<any>;
     labelRequiredFromContext?: boolean;
 }
 


### PR DESCRIPTION
use same type than the one define in sub component `DirectoryItemSelector`