### PR TITLE
fix(directory-item-selector-props): remove unnecessary undefined type

### DIFF
--- a/src/components/DirectoryItemSelector/directory-item-selector.tsx
+++ b/src/components/DirectoryItemSelector/directory-item-selector.tsx
@@ -42,7 +42,7 @@ interface DirectoryItemSelectorProps {
     fetchElementsInfos: (
         ids: UUID[],
         elementTypes: string[],
-        equipmentTypes?: string[]
+        equipmentTypes: string[]
     ) => Promise<any>;
     classes?: any;
     contentText?: string;


### PR DESCRIPTION
Remove unnecessary undefined, as we always want to filter on equipment types.