### PR TITLE
New hook to subscribe to announcements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
                 "react-intl": "^6.0.0",
                 "react-resizable": "^3.0.4",
                 "react-router-dom": "^6.0.0",
+                "reconnecting-websocket": "^4.4.0",
                 "ts-node": "^10.9.2",
                 "type-fest": "^2.0.0",
                 "typescript": "5.1.6",
@@ -89,6 +90,7 @@
                 "react-hook-form": "^7.41.0",
                 "react-intl": "^6.0.0",
                 "react-router-dom": "^6.0.0",
+                "reconnecting-websocket": "^4.4.0",
                 "yup": "^1.0.0"
             }
         },
@@ -12276,6 +12278,12 @@
                 "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0",
                 "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0"
             }
+        },
+        "node_modules/reconnecting-websocket": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
+            "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng==",
+            "dev": true
         },
         "node_modules/regenerate": {
             "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "react-dom": "^18.0.0",
         "react-intl": "^6.0.0",
         "react-hook-form": "^7.41.0",
+        "reconnecting-websocket": "^4.4.0",
         "yup": "^1.0.0"
     },
     "devDependencies": {
@@ -98,6 +99,7 @@
         "utf-8-validate": "^5.0.2",
         "@react-hook/window-size": "^3.1.1",
         "react-resizable": "^3.0.4",
+        "reconnecting-websocket": "^4.4.0",
         "vite": "^5.0.11",
         "vite-plugin-eslint": "^1.8.1",
         "vite-plugin-svgr": "^4.2.0",

--- a/src/hooks/useGlobalNotificationsSubscriber.ts
+++ b/src/hooks/useGlobalNotificationsSubscriber.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { useEffect, useRef } from 'react';
+import { SnackbarKey, useSnackbar } from 'notistack';
+import ReconnectingWebSocket from 'reconnecting-websocket';
+
+const HEADER_MAINTENANCE = 'maintenance';
+const HEADER_CANCEL_MAINTENANCE = 'cancelMaintenance';
+
+/**
+ * Subscribe to announcements created by admins for users (snackbar with a message which appear at the top of the page)
+ */
+export function useAnnouncementsSubscriber(
+    webSocketUrl: string,
+    token: string
+) {
+    const { enqueueSnackbar, closeSnackbar } = useSnackbar();
+
+    // we use a ref to avoid useless trigger of the useEffect
+    const announcementSnackbarKey = useRef<SnackbarKey>();
+
+    useEffect(() => {
+        // When the web app using this hook starts, the token is usually not ready yet
+        if (!token) {
+            return;
+        }
+
+        const rws = new ReconnectingWebSocket(
+            webSocketUrl + '?access_token=' + token
+        );
+
+        rws.addEventListener('open', () => {
+            console.info('WebSocket for announcements is connected');
+        });
+
+        rws.addEventListener('message', (event) => {
+            let eventData = JSON.parse(event.data);
+            if (eventData.headers.messageType === HEADER_MAINTENANCE) {
+                //first we close the previous snackbar (no need to check if there is one because closeSnackbar doesn't fail on null or wrong id)
+                closeSnackbar(announcementSnackbarKey.current);
+                announcementSnackbarKey.current = enqueueSnackbar(
+                    eventData.payload,
+                    {
+                        variant: 'info',
+                        style: {
+                            whiteSpace: 'pre-line',
+                        },
+                        anchorOrigin: {
+                            horizontal: 'center',
+                            vertical: 'top',
+                        },
+                        autoHideDuration: eventData.headers.duration
+                            ? eventData.headers.duration * 1000
+                            : null,
+                    }
+                );
+            } else if (
+                eventData.headers.messageType === HEADER_CANCEL_MAINTENANCE
+            ) {
+                //nothing happens if the id is null or if the snackbar it references is already closed
+                closeSnackbar(announcementSnackbarKey.current);
+            }
+        });
+
+        rws.addEventListener('error', (event) => {
+            console.error('Unexpected announcements WebSocket error', event);
+        });
+
+        return () => rws.close();
+    }, [webSocketUrl, token, closeSnackbar, enqueueSnackbar]);
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -104,6 +104,7 @@ export { default as directory_items_input_fr } from './components/translations/d
 export { TagRenderer } from './components/ElementSearchDialog';
 export { EquipmentItem } from './components/ElementSearchDialog/equipment-item';
 export { useIntlRef } from './hooks/useIntlRef';
+export { useAnnouncementsSubscriber } from './hooks/useGlobalNotificationsSubscriber';
 export { default as SliderInput } from './components/react-hook-form/slider-input';
 export { default as TextFieldWithAdornment } from './components/react-hook-form/utils/text-field-with-adornment';
 export {

--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,7 @@ export { default as CardErrorBoundary } from './components/CardErrorBoundary';
 export { useIntlRef } from './hooks/useIntlRef';
 export { useSnackMessage } from './hooks/useSnackMessage';
 export { useDebounce } from './hooks/useDebounce';
+export { useAnnouncementsSubscriber } from './hooks/useGlobalNotificationsSubscriber';
 export { default as AutocompleteInput } from './components/react-hook-form/autocomplete-input';
 export { default as TextInput } from './components/react-hook-form/text-input';
 export { default as ExpandingTextField } from './components/react-hook-form/ExpandingTextField';


### PR DESCRIPTION
Add useAnnouncementsSubscriber hook to subscribe via websocket to global notifications (announcements).
When new message, it display a snackbar at the top of the page.

from https://github.com/gridsuite/gridstudy-app/pull/1902 and https://github.com/gridsuite/gridexplore-app/pull/346 