### PR TITLE
Add CustomFormProvider

### DIFF
--- a/demo/src/InputsTab.jsx
+++ b/demo/src/InputsTab.jsx
@@ -20,7 +20,7 @@ import CheckboxInput from '../../src/components/react-hook-form/booleans/checkbo
 import SwitchInput from '../../src/components/react-hook-form/booleans/switch-input';
 import SubmitButton from '../../src/components/react-hook-form/utils/submit-button';
 import ExpandingTextField from '../../src/components/react-hook-form/ExpandingTextField';
-import CustomFormProvider from '../../src/components/react-hook-form/custom-form-provider';
+import CustomFormProvider from '../../src/components/react-hook-form/provider/custom-form-provider';
 
 const AUTOCOMPLETE_INPUT = 'autocomplete';
 const TEXT_INPUT = 'text';

--- a/demo/src/InputsTab.jsx
+++ b/demo/src/InputsTab.jsx
@@ -7,7 +7,7 @@
 
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { FormProvider, useForm } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import { Box, Grid } from '@mui/material';
 import AutocompleteInput from '../../src/components/react-hook-form/autocomplete-input';
 import TextInput from '../../src/components/react-hook-form/text-input';
@@ -20,6 +20,7 @@ import CheckboxInput from '../../src/components/react-hook-form/booleans/checkbo
 import SwitchInput from '../../src/components/react-hook-form/booleans/switch-input';
 import SubmitButton from '../../src/components/react-hook-form/utils/submit-button';
 import ExpandingTextField from '../../src/components/react-hook-form/ExpandingTextField';
+import CustomFormProvider from '../../src/components/react-hook-form/custom-form-provider';
 
 const AUTOCOMPLETE_INPUT = 'autocomplete';
 const TEXT_INPUT = 'text';
@@ -106,7 +107,7 @@ export function InputsTab() {
     }
 
     return (
-        <FormProvider validationSchema={formSchema} {...formMethods}>
+        <CustomFormProvider validationSchema={formSchema} {...formMethods}>
             <Box
                 sx={{
                     display: 'flex',
@@ -190,6 +191,6 @@ export function InputsTab() {
                     <SubmitButton onClick={handleSubmit(onSubmit, onError)} />
                 </Box>
             </Box>
-        </FormProvider>
+        </CustomFormProvider>
     );
 }

--- a/src/components/react-hook-form/ExpandingTextField.tsx
+++ b/src/components/react-hook-form/ExpandingTextField.tsx
@@ -9,7 +9,7 @@ import { FunctionComponent, useState } from 'react';
 import { TextFieldProps, Theme, Typography } from '@mui/material';
 import { useWatch } from 'react-hook-form';
 import { TextInput, TextInputProps } from '../..';
-import { useCustomFormContext } from './custom-form-provider.tsx';
+import { useCustomFormContext } from './provider/use-custom-form-context';
 
 interface ExpandingTextFieldProps extends TextInputProps {
     name: string;

--- a/src/components/react-hook-form/ExpandingTextField.tsx
+++ b/src/components/react-hook-form/ExpandingTextField.tsx
@@ -5,11 +5,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { useState } from 'react';
+import { FunctionComponent, useState } from 'react';
 import { TextFieldProps, Theme, Typography } from '@mui/material';
-import { FunctionComponent } from 'react';
-import { useFormContext, useWatch } from 'react-hook-form';
-import { TextInputProps, TextInput } from '../..';
+import { useWatch } from 'react-hook-form';
+import { TextInput, TextInputProps } from '../..';
+import { useCustomFormContext } from './custom-form-provider.tsx';
 
 interface ExpandingTextFieldProps extends TextInputProps {
     name: string;
@@ -20,6 +20,7 @@ interface ExpandingTextFieldProps extends TextInputProps {
     label?: string;
     textFieldFormProps?: TextFieldProps;
 }
+
 const ExpandingTextField: FunctionComponent<ExpandingTextFieldProps> = ({
     name,
     maxCharactersNumber = 500,
@@ -31,7 +32,7 @@ const ExpandingTextField: FunctionComponent<ExpandingTextFieldProps> = ({
     ...otherTexFieldProps
 }) => {
     const [isFocused, setIsFocused] = useState(false);
-    const { control } = useFormContext();
+    const { control } = useCustomFormContext();
     const descriptionWatch = useWatch({
         name: name,
         control,

--- a/src/components/react-hook-form/autocomplete-input.jsx
+++ b/src/components/react-hook-form/autocomplete-input.jsx
@@ -7,7 +7,7 @@
 
 import PropTypes from 'prop-types';
 import { Autocomplete, TextField } from '@mui/material';
-import { useController, useFormContext } from 'react-hook-form';
+import { useController } from 'react-hook-form';
 import {
     genHelperError,
     genHelperPreviousValue,
@@ -15,6 +15,7 @@ import {
     isFieldRequired,
 } from './utils/functions';
 import FieldLabel from './utils/field-label';
+import { useCustomFormContext } from './custom-form-provider';
 
 const AutocompleteInput = ({
     name,
@@ -29,7 +30,8 @@ const AutocompleteInput = ({
     formProps,
     ...props
 }) => {
-    const { validationSchema, getValues, removeOptional } = useFormContext();
+    const { validationSchema, getValues, removeOptional } =
+        useCustomFormContext();
     const {
         field: { onChange, value, ref },
         fieldState: { error },

--- a/src/components/react-hook-form/autocomplete-input.jsx
+++ b/src/components/react-hook-form/autocomplete-input.jsx
@@ -15,7 +15,7 @@ import {
     isFieldRequired,
 } from './utils/functions';
 import FieldLabel from './utils/field-label';
-import { useCustomFormContext } from './custom-form-provider';
+import { useCustomFormContext } from './provider/use-custom-form-context';
 
 const AutocompleteInput = ({
     name,

--- a/src/components/react-hook-form/custom-form-provider.tsx
+++ b/src/components/react-hook-form/custom-form-provider.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, PropsWithChildren, useContext } from 'react';
+import { FormProvider, useFormContext, UseFormReturn } from 'react-hook-form';
+import * as yup from 'yup';
+
+type CustomFormContextProps = {
+    removeOptional?: boolean;
+    validationSchema: yup.AnySchema;
+};
+
+type MergedFormContextProps = UseFormReturn<any> & CustomFormContextProps;
+
+type CustomFormProviderProps = PropsWithChildren<MergedFormContextProps>;
+
+const CustomFormContext = createContext<CustomFormContextProps>({
+    removeOptional: false,
+    validationSchema: yup.object(),
+});
+
+const CustomFormProvider = (props: CustomFormProviderProps) => {
+    const { validationSchema, removeOptional, children, ...formMethods } =
+        props;
+
+    return (
+        <FormProvider {...formMethods}>
+            <CustomFormContext.Provider
+                value={{
+                    validationSchema: validationSchema,
+                    removeOptional: removeOptional,
+                }}
+            >
+                {children}
+            </CustomFormContext.Provider>
+        </FormProvider>
+    );
+};
+
+export default CustomFormProvider;
+
+export const useCustomFormContext = (): MergedFormContextProps => {
+    const formMethods = useFormContext();
+    const customFormMethods = useContext(CustomFormContext);
+
+    return { ...formMethods, ...customFormMethods };
+};

--- a/src/components/react-hook-form/custom-form-provider.tsx
+++ b/src/components/react-hook-form/custom-form-provider.tsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 import React, { createContext, PropsWithChildren, useContext } from 'react';
 import { FormProvider, useFormContext, UseFormReturn } from 'react-hook-form';
 import * as yup from 'yup';

--- a/src/components/react-hook-form/directory-items-input.tsx
+++ b/src/components/react-hook-form/directory-items-input.tsx
@@ -25,9 +25,9 @@ import MidFormError from '../react-hook-form/error-management/mid-form-error.jsx
 import { RawReadOnlyInput } from './raw-read-only-input';
 import { mergeSx } from '../../utils/styles.js';
 import DirectoryItemSelector from '../DirectoryItemSelector/directory-item-selector.tsx';
-import { isFieldFromContextRequired } from './utils/functions.jsx';
 import { UUID } from 'crypto';
 import { useCustomFormContext } from './custom-form-provider.tsx';
+import { isFieldRequired } from './utils/functions';
 
 export const NAME = 'name';
 
@@ -113,7 +113,7 @@ const DirectoryItemsInput: FunctionComponent<DirectoryItemsInputProps> = ({
     });
 
     const formContext = useCustomFormContext();
-    const { getValues } = formContext;
+    const { getValues, validationSchema } = formContext;
     const {
         fieldState: { error },
     } = useController({
@@ -169,9 +169,9 @@ const DirectoryItemsInput: FunctionComponent<DirectoryItemsInputProps> = ({
                         label={label}
                         optional={
                             labelRequiredFromContext &&
-                            !isFieldFromContextRequired(
+                            !isFieldRequired(
                                 name,
-                                formContext,
+                                validationSchema,
                                 getValues()
                             )
                         }

--- a/src/components/react-hook-form/directory-items-input.tsx
+++ b/src/components/react-hook-form/directory-items-input.tsx
@@ -5,22 +5,29 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Grid, Theme, Chip, FormControl, IconButton } from '@mui/material';
+import {
+    Chip,
+    FormControl,
+    Grid,
+    IconButton,
+    Theme,
+    Tooltip,
+} from '@mui/material';
 import OverflowableText from '../OverflowableText';
 import { useSnackMessage } from '../../hooks/useSnackMessage';
 import FieldLabel from './utils/field-label';
 import FolderIcon from '@mui/icons-material/Folder';
 import { FunctionComponent, useCallback, useMemo, useState } from 'react';
-import { useController, useFieldArray, useFormContext } from 'react-hook-form';
+import { useController, useFieldArray } from 'react-hook-form';
 import { useIntl } from 'react-intl';
 import ErrorInput from '../react-hook-form/error-management/error-input.jsx';
 import MidFormError from '../react-hook-form/error-management/mid-form-error.jsx';
 import { RawReadOnlyInput } from './raw-read-only-input';
-import { Tooltip } from '@mui/material';
 import { mergeSx } from '../../utils/styles.js';
 import DirectoryItemSelector from '../DirectoryItemSelector/directory-item-selector.tsx';
 import { isFieldFromContextRequired } from './utils/functions.jsx';
 import { UUID } from 'crypto';
+import { useCustomFormContext } from './custom-form-provider.tsx';
 
 export const NAME = 'name';
 
@@ -105,7 +112,7 @@ const DirectoryItemsInput: FunctionComponent<DirectoryItemsInputProps> = ({
         name,
     });
 
-    const formContext = useFormContext();
+    const formContext = useCustomFormContext();
     const { getValues } = formContext;
     const {
         fieldState: { error },

--- a/src/components/react-hook-form/directory-items-input.tsx
+++ b/src/components/react-hook-form/directory-items-input.tsx
@@ -26,7 +26,7 @@ import { RawReadOnlyInput } from './raw-read-only-input';
 import { mergeSx } from '../../utils/styles.js';
 import DirectoryItemSelector from '../DirectoryItemSelector/directory-item-selector.tsx';
 import { UUID } from 'crypto';
-import { useCustomFormContext } from './custom-form-provider.tsx';
+import { useCustomFormContext } from './provider/use-custom-form-context';
 import { isFieldRequired } from './utils/functions';
 
 export const NAME = 'name';

--- a/src/components/react-hook-form/provider/custom-form-provider.tsx
+++ b/src/components/react-hook-form/provider/custom-form-provider.tsx
@@ -1,12 +1,12 @@
 /**
- * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { createContext, PropsWithChildren, useContext } from 'react';
-import { FormProvider, useFormContext, UseFormReturn } from 'react-hook-form';
+import React, { createContext, PropsWithChildren } from 'react';
+import { FormProvider, UseFormReturn } from 'react-hook-form';
 import * as yup from 'yup';
 
 type CustomFormContextProps = {
@@ -14,11 +14,12 @@ type CustomFormContextProps = {
     validationSchema: yup.AnySchema;
 };
 
-type MergedFormContextProps = UseFormReturn<any> & CustomFormContextProps;
+export type MergedFormContextProps = UseFormReturn<any> &
+    CustomFormContextProps;
 
 type CustomFormProviderProps = PropsWithChildren<MergedFormContextProps>;
 
-const CustomFormContext = createContext<CustomFormContextProps>({
+export const CustomFormContext = createContext<CustomFormContextProps>({
     removeOptional: false,
     validationSchema: yup.object(),
 });
@@ -42,10 +43,3 @@ const CustomFormProvider = (props: CustomFormProviderProps) => {
 };
 
 export default CustomFormProvider;
-
-export const useCustomFormContext = (): MergedFormContextProps => {
-    const formMethods = useFormContext();
-    const customFormMethods = useContext(CustomFormContext);
-
-    return { ...formMethods, ...customFormMethods };
-};

--- a/src/components/react-hook-form/provider/use-custom-form-context.ts
+++ b/src/components/react-hook-form/provider/use-custom-form-context.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { useFormContext } from 'react-hook-form';
+import { useContext } from 'react';
+import {
+    CustomFormContext,
+    MergedFormContextProps,
+} from './custom-form-provider';
+
+export const useCustomFormContext = (): MergedFormContextProps => {
+    const formMethods = useFormContext();
+    const customFormMethods = useContext(CustomFormContext);
+
+    return { ...formMethods, ...customFormMethods };
+};

--- a/src/components/react-hook-form/text-input.jsx
+++ b/src/components/react-hook-form/text-input.jsx
@@ -17,7 +17,7 @@ import {
     identity,
     isFieldRequired,
 } from './utils/functions';
-import { useCustomFormContext } from './custom-form-provider';
+import { useCustomFormContext } from './provider/use-custom-form-context';
 
 const TextInput = ({
     name,

--- a/src/components/react-hook-form/text-input.jsx
+++ b/src/components/react-hook-form/text-input.jsx
@@ -8,7 +8,7 @@
 import PropTypes from 'prop-types';
 import { IconButton, InputAdornment, TextField } from '@mui/material';
 import { Clear as ClearIcon } from '@mui/icons-material';
-import { useController, useFormContext } from 'react-hook-form';
+import { useController } from 'react-hook-form';
 import TextFieldWithAdornment from './utils/text-field-with-adornment';
 import FieldLabel from './utils/field-label';
 import {
@@ -17,6 +17,7 @@ import {
     identity,
     isFieldRequired,
 } from './utils/functions';
+import { useCustomFormContext } from './custom-form-provider';
 
 const TextInput = ({
     name,
@@ -32,7 +33,8 @@ const TextInput = ({
     clearable,
     formProps,
 }) => {
-    const { validationSchema, getValues, removeOptional } = useFormContext();
+    const { validationSchema, getValues, removeOptional } =
+        useCustomFormContext();
     const {
         field: { onChange, value, ref },
         fieldState: { error },

--- a/src/components/react-hook-form/utils/functions.jsx
+++ b/src/components/react-hook-form/utils/functions.jsx
@@ -32,13 +32,6 @@ export function identity(x) {
     return x;
 }
 
-// When using Typescript, you can't get the validation schema from useFormContext (because it is a custom prop)
-// this method can be used instead in Typescript files
-export const isFieldFromContextRequired = (fieldName, formContext, values) => {
-    const { validationSchema } = formContext;
-    return isFieldRequired(fieldName, validationSchema, values);
-};
-
 export const isFieldRequired = (fieldName, schema, values) => {
     const { schema: fieldSchema, parent: parentValues } =
         getIn(schema, fieldName, values) || {};

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -104,6 +104,7 @@ export { default as directory_items_input_fr } from './components/translations/d
 export { TagRenderer } from './components/ElementSearchDialog';
 export { EquipmentItem } from './components/ElementSearchDialog/equipment-item';
 export { useIntlRef } from './hooks/useIntlRef';
+export { default as CustomFormProvider } from './components/react-hook-form/custom-form-provider';
 export { default as SliderInput } from './components/react-hook-form/slider-input';
 export { default as TextFieldWithAdornment } from './components/react-hook-form/utils/text-field-with-adornment';
 export {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -104,10 +104,8 @@ export { default as directory_items_input_fr } from './components/translations/d
 export { TagRenderer } from './components/ElementSearchDialog';
 export { EquipmentItem } from './components/ElementSearchDialog/equipment-item';
 export { useIntlRef } from './hooks/useIntlRef';
-export {
-    default as CustomFormProvider,
-    useCustomFormContext,
-} from './components/react-hook-form/custom-form-provider';
+export { useCustomFormContext } from './components/react-hook-form/provider/use-custom-form-context';
+export { default as CustomFormProvider } from './components/react-hook-form/provider/custom-form-provider';
 export { default as SliderInput } from './components/react-hook-form/slider-input';
 export { default as TextFieldWithAdornment } from './components/react-hook-form/utils/text-field-with-adornment';
 export {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,9 +9,9 @@ import type { FunctionComponent, ReactElement } from 'react';
 import type { AutocompleteProps } from '@mui/material/Autocomplete/Autocomplete';
 import type {
     ButtonProps,
-    SwitchProps,
     CheckboxProps,
     RadioGroupProps,
+    SwitchProps,
     SxProps,
     TextFieldProps,
 } from '@mui/material';
@@ -104,7 +104,10 @@ export { default as directory_items_input_fr } from './components/translations/d
 export { TagRenderer } from './components/ElementSearchDialog';
 export { EquipmentItem } from './components/ElementSearchDialog/equipment-item';
 export { useIntlRef } from './hooks/useIntlRef';
-export { default as CustomFormProvider } from './components/react-hook-form/custom-form-provider';
+export {
+    default as CustomFormProvider,
+    useCustomFormContext,
+} from './components/react-hook-form/custom-form-provider';
 export { default as SliderInput } from './components/react-hook-form/slider-input';
 export { default as TextFieldWithAdornment } from './components/react-hook-form/utils/text-field-with-adornment';
 export {

--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,7 @@ export { default as CardErrorBoundary } from './components/CardErrorBoundary';
 export { useIntlRef } from './hooks/useIntlRef';
 export { useSnackMessage } from './hooks/useSnackMessage';
 export { useDebounce } from './hooks/useDebounce';
+export { default as CustomFormProvider } from './components/react-hook-form/custom-form-provider';
 export { default as AutocompleteInput } from './components/react-hook-form/autocomplete-input';
 export { default as TextInput } from './components/react-hook-form/text-input';
 export { default as ExpandingTextField } from './components/react-hook-form/ExpandingTextField';

--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,10 @@ export { default as CardErrorBoundary } from './components/CardErrorBoundary';
 export { useIntlRef } from './hooks/useIntlRef';
 export { useSnackMessage } from './hooks/useSnackMessage';
 export { useDebounce } from './hooks/useDebounce';
-export { default as CustomFormProvider } from './components/react-hook-form/custom-form-provider';
+export {
+    default as CustomFormProvider,
+    useCustomFormContext,
+} from './components/react-hook-form/custom-form-provider';
 export { default as AutocompleteInput } from './components/react-hook-form/autocomplete-input';
 export { default as TextInput } from './components/react-hook-form/text-input';
 export { default as ExpandingTextField } from './components/react-hook-form/ExpandingTextField';

--- a/src/index.js
+++ b/src/index.js
@@ -96,10 +96,8 @@ export { default as CardErrorBoundary } from './components/CardErrorBoundary';
 export { useIntlRef } from './hooks/useIntlRef';
 export { useSnackMessage } from './hooks/useSnackMessage';
 export { useDebounce } from './hooks/useDebounce';
-export {
-    default as CustomFormProvider,
-    useCustomFormContext,
-} from './components/react-hook-form/custom-form-provider';
+export { useCustomFormContext } from './components/react-hook-form/provider/use-custom-form-context';
+export { default as CustomFormProvider } from './components/react-hook-form/provider/custom-form-provider';
 export { default as AutocompleteInput } from './components/react-hook-form/autocomplete-input';
 export { default as TextInput } from './components/react-hook-form/text-input';
 export { default as ExpandingTextField } from './components/react-hook-form/ExpandingTextField';


### PR DESCRIPTION
Add CustomFormProvider for enhanced form management with some added custom props.

Now we can use a TypeScript compliant form provider.

From https://github.com/gridsuite/gridstudy-app/blob/poc_typescript/src/components/refactor/utils/custom-form-context.tsx