### PR TITLE
After the API update that restores the correct order of directories i…

### DIFF
--- a/src/components/dialogs/modify-element-selection.tsx
+++ b/src/components/dialogs/modify-element-selection.tsx
@@ -45,7 +45,6 @@ const ModifyElementSelection: React.FunctionComponent<
                 setActiveDirectoryName(
                     res
                         .map((element: any) => element.elementName.trim())
-                        .reverse()
                         .join('/')
                 );
             });

--- a/src/components/inputs/react-hook-form/directory-items-input.tsx
+++ b/src/components/inputs/react-hook-form/directory-items-input.tsx
@@ -178,7 +178,6 @@ const DirectoryItemsInput: FunctionComponent<DirectoryItemsInputProps> = ({
             if (chip) {
                 fetchDirectoryElementPath(chip).then((response: any[]) => {
                     const path = response
-                        .reverse() // we reverse the order so the root parent is first in the list
                         .filter((e) => e.elementUuid !== chip)
                         .map((e) => e.elementUuid);
 


### PR DESCRIPTION
…n path, we have to undo the "reverse" that was previously done.