### PR TITLE
Fix PR #493

### DIFF
--- a/src/components/TopBar/AboutDialog.tsx
+++ b/src/components/TopBar/AboutDialog.tsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useState } from 'react';
 import {
     Accordion,
     AccordionDetails,
@@ -204,18 +204,15 @@ const AboutDialog = ({
     const [loadingAdditionalModules, setLoadingAdditionalModules] =
         useState(false);
     const [modules, setModules] = useState<GridSuiteModule[] | null>(null);
-    const currentApp: GridSuiteModule = useMemo(
-        () => ({
-            name: (!!logo && appName) || `Grid${appName}`,
-            type: 'app',
-            version: appVersion,
-            gitTag: appGitTag,
-            license: appLicense,
-        }),
-        [logo, appName, appVersion, appGitTag, appLicense]
-    );
     useEffect(() => {
         if (open) {
+            const currentApp: GridSuiteModule = {
+                name: `Grid${appName}`,
+                type: 'app',
+                version: appVersion,
+                gitTag: appGitTag,
+                license: appLicense,
+            };
             (additionalModulesPromise
                 ? Promise.resolve(setLoadingAdditionalModules(true)).then(() =>
                       additionalModulesPromise()
@@ -231,7 +228,14 @@ const AboutDialog = ({
                 })
                 .finally(() => setLoadingAdditionalModules(false));
         }
-    }, [open, additionalModulesPromise, currentApp]);
+    }, [
+        open,
+        additionalModulesPromise,
+        appName,
+        appVersion,
+        appGitTag,
+        appLicense,
+    ]);
 
     const handleClose = useCallback(() => {
         if (onClose) {

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -663,11 +663,7 @@ const TopBar = ({
                     appLicense={appLicense}
                     globalVersionPromise={globalVersionPromise}
                     additionalModulesPromise={additionalModulesPromise}
-                    logo={
-                        logoAboutDialog === null
-                            ? logo_clickable
-                            : logoAboutDialog
-                    }
+                    logo={logoAboutDialog}
                 />
             </Toolbar>
         </AppBar>

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -663,7 +663,11 @@ const TopBar = ({
                     appLicense={appLicense}
                     globalVersionPromise={globalVersionPromise}
                     additionalModulesPromise={additionalModulesPromise}
-                    logo={logoAboutDialog}
+                    logo={
+                        logoAboutDialog === null
+                            ? logo_clickable
+                            : logoAboutDialog
+                    }
                 />
             </Toolbar>
         </AppBar>


### PR DESCRIPTION
Fix broken module name in 901ce6a67452abfd2fe239c3eb66359c45d211a5
* Have revert module name composition to before #493
* ~Simplify logo usage, so~
  - ~`<TopBar /*...*/ />` or `<TopBar logoAboutDialog={undefined} /*...*/ />`: give the "GridSuite" logo we have in GridSuite apps~
  - ~`<TopBar logoAboutDialog={null} /*...*/ />`: give the same logo than in top-bar (reuse the same instance internally)~
  - ~`<TopBar logoAboutDialog={anything} /*...*/ />`: will use the _anything_ ReactNode in place of the logo~
