### PR TITLE
Add notifications to publish process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,3 +16,18 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # No need to use another action to retreive release infos, there in the event payload
+      # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+      # https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=published#release
+      # data example: https://api.github.com/repos/gridsuite/commons-ui/releases/tags/v0.61.3
+      - name: Send notification to the team
+        uses: dawidd6/action-send-mail@v3
+        with:
+          connection_url: ${{secrets.NOTIF_MAIL_ADDRESS}}
+          #ignore_cert: true
+          from: '"${{ github.actor }}" <${{secrets.NOTIF_MAIL_SENDER}}>'
+          to: ${{secrets.NOTIF_MAIL_RECIPIENTS_RELEASE}}
+          reply_to: no-reply@rte-france.com
+          subject: Release of ${{ github.repository }} ${{ github.event.release.name }} by ${{ event.release.author.login }}
+          body: ${{ github.event.release.body }}
+          convert_markdown: true


### PR DESCRIPTION
Add release notification to team in the publish workflow.

We need to create these secrets:
* `NOTIF_MAIL_ADDRESS` = `smtp://user:password@smtp.gmail.com:465`
* `NOTIF_MAIL_SENDER` = `qqqqqqq@gmail.com`
* `NOTIF_MAIL_RECIPIENTS_RELEASE` = `Release - GridSuite Team <aaaaaaaa.bbbbbbb.onmicrosoft.com@fr.teams.ms>`
