### PR TITLE
fix: remove hack reload key after logout

### DIFF
--- a/src/utils/AuthService.ts
+++ b/src/utils/AuthService.ts
@@ -266,6 +266,7 @@ function login(location: Location, userManagerInstance: UserManager) {
 
 function logout(dispatch: Dispatch<unknown>, userManagerInstance: UserManager) {
     sessionStorage.removeItem(hackAuthorityKey); //To remove when hack is removed
+    sessionStorage.removeItem(oidcHackReloadedKey);
     return userManagerInstance.getUser().then((user) => {
         if (user) {
             // We don't need to check if token is valid at this point


### PR DESCRIPTION
After connecting, deconnecting then reconnecting the hack reload key is not removed in the session storage then last connexion does not reload then the hack does not work.