### PR TITLE
fix jest transpiling all node modules, make tests fast again

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,7 +14,9 @@ const config: Config = {
         '^.+\\.(css|less|scss)$': 'identity-obj-proxy',
     },
     // see https://github.com/react-dnd/react-dnd/issues/3443
-    transformIgnorePatterns: ['node_modules/(?!react-dnd)/'],
+    transformIgnorePatterns: [
+        'node_modules/(?!react-dnd|dnd-core|@react-dnd)',
+    ], // transform from ESM
     globals: {
         IS_REACT_ACT_ENVIRONMENT: true,
     },


### PR DESCRIPTION
the previous regexp is bugged, it requires '//' in the filename !! As a result, all the files in node_modules don't pass the regex so nothing is ignored => everything is transformed

jest caches this in /tmp/jest_* so rerunning tests is fast, but the first time jest takes minutes to transform everything

also the previous regex was incomplete (missing other files that need transforming) but this was not visible because it transformed everything anayway