### PR TITLE
Fix ElementIcon: missing type management in switch

### DIFF
--- a/src/utils/mapper/elementIcon.tsx
+++ b/src/utils/mapper/elementIcon.tsx
@@ -27,6 +27,7 @@ function getFileIcon(type: ElementType, style: SxProps<Theme>) {
             return <NoteAltIcon sx={style} />;
         case ElementType.FILTER:
             return <ArticleIcon sx={style} />;
+        case ElementType.PARAMETERS:
         case ElementType.VOLTAGE_INIT_PARAMETERS:
         case ElementType.SECURITY_ANALYSIS_PARAMETERS:
         case ElementType.LOADFLOW_PARAMETERS:


### PR DESCRIPTION
causing console Warning:
unknown type [PARAMETERS]