### PR TITLE
Prevents the TreeViewFinder's dialog from closing when clicking in the backdrop

### DIFF
--- a/src/components/treeViewFinder/TreeViewFinder.tsx
+++ b/src/components/treeViewFinder/TreeViewFinder.tsx
@@ -382,7 +382,10 @@ function TreeViewFinderComponant(props: TreeViewFinderProps) {
         <Dialog
             open={open}
             onClose={(e, r) => {
-                if (r === 'escapeKeyDown' || r === 'backdropClick') {
+                if (r === 'backdropClick') {
+                    return;
+                }
+                if (r === 'escapeKeyDown') {
                     onClose?.([]);
                     setSelected([]);
                 }


### PR DESCRIPTION
Prevents the TreeViewFinder's dialog from closing when clicking in the backdrop