### PR TITLE
Fix TextField adornments warnings

### DIFF
--- a/src/components/inputs/reactHookForm/text/TextInput.tsx
+++ b/src/components/inputs/reactHookForm/text/TextInput.tsx
@@ -113,7 +113,7 @@ export function TextInput({
             {...genHelperPreviousValue(previousValue!, adornment)}
             {...genHelperError(error?.message)}
             {...formProps}
-            {...finalAdornment}
+            {...(adornment && { ...finalAdornment })}
         />
     );
 }

--- a/src/components/inputs/reactHookForm/utils/TextFieldWithAdornment.tsx
+++ b/src/components/inputs/reactHookForm/utils/TextFieldWithAdornment.tsx
@@ -14,8 +14,8 @@ import { Input } from '../../../../utils/types/types';
 export type TextFieldWithAdornmentProps = TextFieldProps & {
     // variant already included in TextFieldProps
     value: Input; // we override the default type of TextFieldProps which is unknown
-    adornmentPosition: string;
-    adornmentText: string;
+    adornmentPosition?: string;
+    adornmentText?: string;
     handleClearValue?: () => void;
 };
 


### PR DESCRIPTION
Prevents the following warnings :

    Warning: React does not recognize the `adornmentText` prop on a DOM element.
    Warning: React does not recognize the `adornmentPosition` prop on a DOM element.

By not passing those props only when `Field` is a `TextField` instead of a `TextFieldWithAdornment`