### PR TITLE
Remove outdated webpack/chokidar inotify watcher maxlimit bump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,6 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: 22
-            - name: FixForNodeWarnings
-              run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
             - name: Build
               run: |


### PR DESCRIPTION
Vite doesn't use webpack/chokidar, it was a thing in nwb a long time ago

See 923078bd4f71 for more information