### PR TITLE
Fix release: also set permission: id-token: write in this repo, not just in the reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ on:
 
 permissions:
   contents: write
+  # permission for npm error Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
+  # permission must be reset here otherwise we get the following error:
+  # > The workflow is not valid. Error calling workflow. The workflow is requesting # 'id-token: write', but is only allowed 'id-token: none'.
+  id-token: write
 
 jobs:
   run-release:


### PR DESCRIPTION
Got the error
The workflow is not valid. Error calling workflow. The workflow is requesting 'id-token: write', but is only allowed 'id-token: none'.