### PR TITLE
Set default value for currentName in UniqueNameInput component

### DIFF
--- a/src/components/inputs/reactHookForm/text/UniqueNameInput.tsx
+++ b/src/components/inputs/reactHookForm/text/UniqueNameInput.tsx
@@ -43,7 +43,7 @@ export function UniqueNameInput({
     autoFocus,
     onManualChangeCallback,
     formProps,
-    currentName,
+    currentName = '',
     activeDirectory,
     sx,
     fullWidth = true,


### PR DESCRIPTION
Fix : to avoid triggering validation when no currentName is set