### PR TITLE
Jest doesn't support object `exports` in `package.json` in ESM mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,7 @@
         "npm": "^10.9.2"
     },
     "type": "module",
-    "exports": {
-        ".": {
-            "import": "./dist/index.js",
-            "types": "./dist/index.d.ts"
-        },
-        "./package.json": "./package.json"
-    },
+    "exports": "./dist/index.js",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "files": [


### PR DESCRIPTION
revert a change in #732