### PR TITLE
Fix a strange JSX bug with icons

### DIFF
--- a/src/components/topBar/MessageBanner.tsx
+++ b/src/components/topBar/MessageBanner.tsx
@@ -6,8 +6,7 @@
  */
 import { ReactNode, useState } from 'react';
 import { Box, type Theme } from '@mui/material';
-import CloseIcon from '@mui/icons-material/Close';
-import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import { Close as CloseIcon, WarningAmber as WarningAmberIcon } from '@mui/icons-material';
 import type { SystemStyleObject } from '@mui/system';
 
 const styles = {


### PR DESCRIPTION
When rendering `<MessageBanner />` in GridStudy, we get the error:
>React.jsx: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: object.

When we add `<CardErrorBoundary/>` around icons :
>Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. Check the render method of `MessageBanner`.

After multiple tries, just changing the import like this resolve the problem.