### PR TITLE
Migrate react-beautiful-dnd to @hello-pangea/dnd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.92.3",
             "license": "MPL-2.0",
             "dependencies": {
+                "@hello-pangea/dnd": "^18.0.1",
                 "@react-querybuilder/dnd": "^8.2.0",
                 "@react-querybuilder/material": "^8.2.0",
                 "autosuggest-highlight": "^3.3.4",
@@ -17,7 +18,6 @@
                 "localized-countries": "^2.0.0",
                 "oidc-client": "^1.11.5",
                 "prop-types": "^15.8.1",
-                "react-beautiful-dnd": "^13.1.1",
                 "react-csv-downloader": "^3.3.0",
                 "react-dnd": "^16.0.1",
                 "react-dnd-html5-backend": "^16.0.1",
@@ -52,7 +52,6 @@
                 "@types/node": "^22.13.4",
                 "@types/prop-types": "^15.7.14",
                 "@types/react": "^18.3.18",
-                "@types/react-beautiful-dnd": "^13.1.8",
                 "@types/react-dom": "^18.3.5",
                 "@types/react-resizable": "^3.0.8",
                 "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -3322,6 +3321,52 @@
                 "tslib": "2"
             }
         },
+        "node_modules/@hello-pangea/dnd": {
+            "version": "18.0.1",
+            "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-18.0.1.tgz",
+            "integrity": "sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.26.7",
+                "css-box-model": "^1.2.1",
+                "raf-schd": "^4.0.3",
+                "react-redux": "^9.2.0",
+                "redux": "^5.0.1"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@hello-pangea/dnd/node_modules/react-redux": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+            "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25 || ^19",
+                "react": "^18.0 || ^19",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@hello-pangea/dnd/node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "license": "MIT"
+        },
         "node_modules/@hookform/resolvers": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-4.0.0.tgz",
@@ -5773,6 +5818,7 @@
             "version": "3.3.6",
             "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
             "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@types/react": "*",
@@ -5941,16 +5987,6 @@
                 "csstype": "^3.0.2"
             }
         },
-        "node_modules/@types/react-beautiful-dnd": {
-            "version": "13.1.8",
-            "resolved": "https://registry.npmjs.org/@types/react-beautiful-dnd/-/react-beautiful-dnd-13.1.8.tgz",
-            "integrity": "sha512-E3TyFsro9pQuK4r8S/OL6G99eq7p8v29sX0PM7oT8Z+PJfZvSQTx4zTQbUJ+QZXioAF0e7TGBEcA1XhYhCweyQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/react": "*"
-            }
-        },
         "node_modules/@types/react-dom": {
             "version": "18.3.5",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
@@ -5966,6 +6002,8 @@
             "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
             "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@types/hoist-non-react-statics": "^3.3.0",
                 "@types/react": "*",
@@ -12998,12 +13036,6 @@
             "dev": true,
             "license": "CC0-1.0"
         },
-        "node_modules/memoize-one": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-            "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-            "license": "MIT"
-        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -14173,26 +14205,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/react-beautiful-dnd": {
-            "version": "13.1.1",
-            "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
-            "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
-            "deprecated": "react-beautiful-dnd is now deprecated. Context and options: https://github.com/atlassian/react-beautiful-dnd/issues/2672",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@babel/runtime": "^7.9.2",
-                "css-box-model": "^1.2.0",
-                "memoize-one": "^5.1.1",
-                "raf-schd": "^4.0.2",
-                "react-redux": "^7.2.0",
-                "redux": "^4.0.4",
-                "use-memo-one": "^1.1.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
-            }
-        },
         "node_modules/react-csv-downloader": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/react-csv-downloader/-/react-csv-downloader-3.3.0.tgz",
@@ -14375,6 +14387,8 @@
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
             "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.15.4",
                 "@types/react-redux": "^7.1.20",
@@ -14399,7 +14413,9 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/react-refresh": {
             "version": "0.14.2",
@@ -16374,15 +16390,6 @@
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
-            }
-        },
-        "node_modules/use-memo-one": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
-            "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "licenses-check": "license-checker --summary --excludePrivatePackages --production --onlyAllow \"$( jq -r .onlyAllow[] license-checker-config.json | tr '\n' ';')\" --excludePackages \"$( jq -r .excludePackages[] license-checker-config.json | tr '\n' ';')\""
     },
     "dependencies": {
+        "@hello-pangea/dnd": "^18.0.1",
         "@react-querybuilder/dnd": "^8.2.0",
         "@react-querybuilder/material": "^8.2.0",
         "autosuggest-highlight": "^3.3.4",
@@ -42,7 +43,6 @@
         "localized-countries": "^2.0.0",
         "oidc-client": "^1.11.5",
         "prop-types": "^15.8.1",
-        "react-beautiful-dnd": "^13.1.1",
         "react-csv-downloader": "^3.3.0",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
@@ -96,7 +96,6 @@
         "@types/node": "^22.13.4",
         "@types/prop-types": "^15.7.14",
         "@types/react": "^18.3.18",
-        "@types/react-beautiful-dnd": "^13.1.8",
         "@types/react-dom": "^18.3.5",
         "@types/react-resizable": "^3.0.8",
         "@typescript-eslint/eslint-plugin": "^7.18.0",

--- a/src/components/checkBoxList/CheckBoxList.tsx
+++ b/src/components/checkBoxList/CheckBoxList.tsx
@@ -7,7 +7,7 @@
 
 import { useState } from 'react';
 import { Box } from '@mui/material';
-import { DragDropContext, Droppable } from 'react-beautiful-dnd';
+import { DragDropContext, Droppable } from '@hello-pangea/dnd';
 import { CheckBoxListItems } from './CheckBoxListItems';
 import { CheckboxListProps } from './checkBoxList.type';
 

--- a/src/components/checkBoxList/CheckBoxListItems.tsx
+++ b/src/components/checkBoxList/CheckBoxListItems.tsx
@@ -8,7 +8,7 @@
 import { useCallback, useMemo } from 'react';
 import { Checkbox, List, ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
-import { Draggable } from 'react-beautiful-dnd';
+import { Draggable } from '@hello-pangea/dnd';
 import { CheckBoxListItem } from './CheckBoxListItem';
 import { OverflowableText } from '../overflowableText';
 import { DraggableCheckBoxListItem } from './DraggableCheckBoxListItem';

--- a/src/components/checkBoxList/checkBoxList.type.ts
+++ b/src/components/checkBoxList/checkBoxList.type.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ReactElement, ReactNode } from 'react';
-import type { DraggableProvided, DragStart, DropResult } from 'react-beautiful-dnd';
+import type { DraggableProvided, DragStart, DropResult } from '@hello-pangea/dnd';
 import type { SxProps, Theme } from '@mui/material';
 
 export type CheckBoxListItemSx = {


### PR DESCRIPTION
This migration was necessary to support React 19 and maintain compatibility with modern React versions.
react-beautiful-dnd is no longer actively maintained and does not officially support React 19. @hello-pangea/dnd is a direct fork that is actively maintained and has full support for React 19.