### PR TITLE
Docs NPMJS Publish needs permission in gridsuite organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ To fix this, run this command from the app **after** running "npm install"
 #### For integrators
 
 If you want to deploy a new version of commons-ui in the [NPM package registry](https://www.npmjs.com/package/@gridsuite/commons-ui),
-you need to follow the steps below:
+first you need **some permissions**. You need to be a member of the *gridsuite* organization and a member of the *'developers'* team.
+Only in this case, you need to follow the steps below:
 
 - [Make a release action](https://github.com/gridsuite/commons-ui/actions/workflows/release.yml)
 - In the 'run workflow' combobox select, let the branch on main
 - Enter the type of evolution (major | minor | patch)
 - Enter your NPM access token (it must be an **automation** access token to bypass 2FA, see the [access token documentation](https://docs.npmjs.com/creating-and-viewing-access-tokens) for details)
 - Click 'run workflow'
+
+Otherwise ask someone who has the permission.
 
 #### License Headers and dependencies checking
 


### PR DESCRIPTION
docs(README): Add a remark in README to specify that you need permission on npmjs to publish a version of the lib