### PR TITLE
Fix NaN in previous value

### DIFF
--- a/src/components/inputs/reactHookForm/utils/HelperPreviousValue.tsx
+++ b/src/components/inputs/reactHookForm/utils/HelperPreviousValue.tsx
@@ -27,7 +27,11 @@ export function HelperPreviousValue({
 
     // this is not a real TS check as (previousValue === undefined)
     // but prevent some bypassed TS checks from a parent which possibly sends null
-    if ((!previousValue && previousValue !== 0) || Number.isNaN(previousValue)) {
+    if (
+        (!previousValue && previousValue !== 0) ||
+        Number.isNaN(previousValue) ||
+        previousValue === 'NaN' /* TODO to remove when network-map-server never return string 'NaN' */
+    ) {
         return undefined;
     }
 


### PR DESCRIPTION
This is a quick solution dedicated only for string 'NaN' previous values in modification formula, not solve the whole problem 'NaN' in gridsuite due to the return from network-map-server.

If the solution in this PR https://github.com/gridsuite/network-map-server/pull/251 is accepted (then merge), we can remove the check previousValue === 'NaN' of the PR