### PR TITLE
Change limit reductions labels

### DIFF
--- a/src/components/parameters/common/limitreductions/limit-reduction-table-cell.tsx
+++ b/src/components/parameters/common/limitreductions/limit-reduction-table-cell.tsx
@@ -6,23 +6,36 @@
  */
 
 import { TableCell } from '@mui/material';
-import { LimitReductionIColumnsDef, LIMIT_REDUCTIONS_FORM, VOLTAGE_LEVELS_FORM } from './columns-definitions';
+import { useIntl } from 'react-intl';
+import { LimitReductionIColumnsDef, LIMIT_REDUCTIONS_FORM, VOLTAGE_LEVELS_FORM, ILimitReductionsByVoltageLevel } from './columns-definitions';
 import { FloatInput, RawReadOnlyInput } from '../../../inputs';
 
 export function LimitReductionTableCell({
     rowIndex,
     column,
+    limits
 }: Readonly<{
     rowIndex: number;
     column: LimitReductionIColumnsDef;
+    limits: ILimitReductionsByVoltageLevel[];
 }>) {
-    return (
-        <TableCell sx={{ fontWeight: 'bold' }}>
-            {column.dataKey === VOLTAGE_LEVELS_FORM ? (
-                <RawReadOnlyInput name={`${LIMIT_REDUCTIONS_FORM}[${rowIndex}].${column.dataKey}`} />
-            ) : (
-                <FloatInput name={`${LIMIT_REDUCTIONS_FORM}[${rowIndex}].${column.dataKey}`} />
+    const intl = useIntl();
+    return column.dataKey === VOLTAGE_LEVELS_FORM ? (
+        <TableCell
+            sx={{ fontWeight: 'bold' }}
+            title={intl.formatMessage(
+                { id: 'VoltageRangeInterval' },
+                {
+                    lowBound: `${limits[rowIndex].voltageLevel.lowBound}`,
+                    highBound: `${limits[rowIndex].voltageLevel.highBound}`,
+                }
             )}
+        >
+            <RawReadOnlyInput name={`${LIMIT_REDUCTIONS_FORM}[${rowIndex}].${column.dataKey}`} />
+        </TableCell>
+    ) : (
+        <TableCell sx={{ fontWeight: 'bold' }}>
+            <FloatInput name={`${LIMIT_REDUCTIONS_FORM}[${rowIndex}].${column.dataKey}`} />
         </TableCell>
     );
 }

--- a/src/components/parameters/common/limitreductions/limit-reduction-table-row.tsx
+++ b/src/components/parameters/common/limitreductions/limit-reduction-table-row.tsx
@@ -7,18 +7,19 @@
 
 import { TableRow } from '@mui/material';
 import { LimitReductionTableCell } from './limit-reduction-table-cell';
-import { LimitReductionIColumnsDef } from './columns-definitions';
+import { ILimitReductionsByVoltageLevel, LimitReductionIColumnsDef } from './columns-definitions';
 
 interface TableRowComponentProps {
     columnsDefinition: LimitReductionIColumnsDef[];
     index: number;
+    limits: ILimitReductionsByVoltageLevel[];
 }
 
-export function LimitReductionTableRow({ columnsDefinition, index }: Readonly<TableRowComponentProps>) {
+export function LimitReductionTableRow({ columnsDefinition, index, limits }: Readonly<TableRowComponentProps>) {
     return (
         <TableRow>
             {columnsDefinition.map((column: LimitReductionIColumnsDef) => (
-                <LimitReductionTableCell key={`${column.dataKey}`} rowIndex={index} column={column} />
+                <LimitReductionTableCell key={`${column.dataKey}`} rowIndex={index} column={column} limits={limits} />
             ))}
         </TableRow>
     );

--- a/src/components/parameters/common/limitreductions/limit-reductions-table-form.tsx
+++ b/src/components/parameters/common/limitreductions/limit-reductions-table-form.tsx
@@ -15,31 +15,43 @@ import {
 } from './columns-definitions';
 import { CustomVoltageLevelTable } from '../voltage-level-table';
 
-const getLabelColumn = (limit: ITemporaryLimitReduction) => {
-    const lowBound = `${Math.trunc(limit.limitDuration.lowBound / 60)} min`;
-    const highBoundValue = Math.trunc(limit.limitDuration.highBound / 60);
-    const highBound = highBoundValue === 0 ? '∞' : `${Math.trunc(limit.limitDuration.highBound / 60)} min`;
-    const lowerBoundClosed = limit.limitDuration.lowClosed ? '[' : ']';
-    const highBoundClosed = limit.limitDuration.highClosed || null ? ']' : '[';
-    return `${lowerBoundClosed}${lowBound}, ${highBound}${highBoundClosed}`;
-};
-
 export function LimitReductionsTableForm({ limits }: Readonly<{ limits: ILimitReductionsByVoltageLevel[] }>) {
     const intl = useIntl();
 
-    const getToolTipColumn = useCallback(
+    const getLabelColumn = useCallback(
         (limit: ITemporaryLimitReduction) => {
-            const lowBound = Math.trunc(limit.limitDuration.lowBound / 60);
-            const highBound = Math.trunc(limit.limitDuration.highBound / 60);
+            const highBound = Math.trunc(limit.limitDuration.lowBound / 60);
+            const lowBound = Math.trunc(limit.limitDuration.highBound / 60);
+
             if (lowBound === 0) {
-                return intl.formatMessage({ id: 'LimitDurationAfterIST' }, { value: highBound });
+                return intl.formatMessage({ id: 'LimitVoltageAfterIST' }, { highBound: `${highBound}` });
             }
 
             return intl.formatMessage(
+                { id: 'LimitVoltageInterval' },
+                {
+                    lowBound: `${lowBound}`,
+                    highBound: `${highBound}`,
+                }
+            );
+        },
+        [intl]
+    );
+
+    const getToolTipColumn = useCallback(
+        (limit: ITemporaryLimitReduction) => {
+            const lowBound = `${Math.trunc(limit.limitDuration.lowBound / 60)} min`;
+            const highBoundValue = Math.trunc(limit.limitDuration.highBound / 60);
+            const highBound = highBoundValue === 0 ? '∞' : `${Math.trunc(limit.limitDuration.highBound / 60)} min`;
+            const lowerBoundClosed = limit.limitDuration.lowClosed ? '[' : ']';
+            const higherBoundClosed = limit.limitDuration.highClosed || null ? ']' : '[';
+            return intl.formatMessage(
                 { id: 'LimitDurationInterval' },
                 {
-                    lowBound: `IT${lowBound}`,
-                    highBound: highBound === 0 ? 'IST' : `IT${highBound}`,
+                    lowBound: `${lowBound}`,
+                    highBound: `${highBound}`,
+                    higherBoundClosed: `${higherBoundClosed}`,
+                    lowerBoundClosed: `${lowerBoundClosed}`,
                 }
             );
         },
@@ -64,13 +76,14 @@ export function LimitReductionsTableForm({ limits }: Readonly<{ limits: ILimitRe
         }
 
         return columnsDef;
-    }, [intl, limits, getToolTipColumn]);
+    }, [intl, limits, getLabelColumn, getToolTipColumn]);
 
     return (
         <CustomVoltageLevelTable
             formName={LIMIT_REDUCTIONS_FORM}
             columnsDefinition={columnsDefinition}
             tableHeight={450}
+            limits={limits}
         />
     );
 }

--- a/src/components/parameters/common/voltage-level-table/custom-voltage-level-table.tsx
+++ b/src/components/parameters/common/voltage-level-table/custom-voltage-level-table.tsx
@@ -7,7 +7,11 @@
 import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
 import { useMemo } from 'react';
 import { useFieldArray } from 'react-hook-form';
-import { LimitReductionIColumnsDef, LIMIT_REDUCTIONS_FORM } from '../limitreductions/columns-definitions';
+import {
+    LimitReductionIColumnsDef,
+    LIMIT_REDUCTIONS_FORM,
+    ILimitReductionsByVoltageLevel,
+} from '../limitreductions/columns-definitions';
 import { LimitReductionTableRow } from '../limitreductions/limit-reduction-table-row';
 import { CustomVoltageLevelTableRow } from './custom-voltage-level-table-row';
 
@@ -15,12 +19,14 @@ interface LimitReductionsTableProps {
     columnsDefinition: LimitReductionIColumnsDef[];
     tableHeight: number;
     formName: string;
+    limits?: ILimitReductionsByVoltageLevel[];
 }
 
 export function CustomVoltageLevelTable({
     formName,
     columnsDefinition,
     tableHeight,
+    limits
 }: Readonly<LimitReductionsTableProps>) {
     const { fields: rows } = useFieldArray({
         name: formName,
@@ -62,6 +68,7 @@ export function CustomVoltageLevelTable({
                             columnsDefinition={columnsDefinition}
                             index={index}
                             formName={formName}
+                            limits={limits}
                         />
                     ))}
                 </TableBody>

--- a/src/components/parameters/security-analysis/security-analysis-parameters-selector.tsx
+++ b/src/components/parameters/security-analysis/security-analysis-parameters-selector.tsx
@@ -61,7 +61,6 @@ export function SecurityAnalysisParametersSelector({
                                 sx={{
                                     fontSize: 17,
                                     fontWeight: 'bold',
-                                    textTransform: 'capitalize',
                                 }}
                             />
                         )

--- a/src/translations/en/parameters.ts
+++ b/src/translations/en/parameters.ts
@@ -61,7 +61,7 @@ export const parametersEn = {
     LimitVoltageAfterIST: 'Between PATL and TATL{highBound}',
     LimitDurationInterval: 'Duration {lowerBoundClosed}{lowBound}, {highBound}{higherBoundClosed}',
     voltageRange: 'Voltage range',
-    VoltageRangeInterval: 'Voltage range interval [{lowBound} kV,{highBound} kV]',
+    VoltageRangeInterval: 'Voltage interval [{lowBound} kV,{highBound} kV]',
 
     Provider: 'Provider',
     LimitReduction: 'Limit reduction',

--- a/src/translations/en/parameters.ts
+++ b/src/translations/en/parameters.ts
@@ -56,10 +56,12 @@ export const parametersEn = {
 
     General: 'General',
     LimitReductions: 'Limit reductions',
-    IST: 'IST',
-    LimitDurationInterval: 'Between {highBound} and {lowBound}',
-    LimitDurationAfterIST: 'Beyond IT{value}',
+    IST: 'PATL',
+    LimitVoltageInterval: 'Between TATL{lowBound} and TATL{highBound}',
+    LimitVoltageAfterIST: 'Between PATL and TATL{highBound}',
+    LimitDurationInterval: 'Duration {lowerBoundClosed}{lowBound}, {highBound}{higherBoundClosed}',
     voltageRange: 'Voltage range',
+    VoltageRangeInterval: 'Voltage range interval [{lowBound} kV,{highBound} kV]',
 
     Provider: 'Provider',
     LimitReduction: 'Limit reduction',

--- a/src/translations/fr/parameters.ts
+++ b/src/translations/fr/parameters.ts
@@ -59,9 +59,11 @@ export const parametersFr = {
     General: 'Général',
     LimitReductions: 'Abattements',
     IST: 'IST',
-    LimitDurationInterval: 'Entre {highBound} et {lowBound}',
-    LimitDurationAfterIST: 'Au-delà de IT{value}',
+    LimitVoltageInterval: 'Entre IT{lowBound} et IT{highBound}',
+    LimitVoltageAfterIST: 'Entre IST et IT{highBound}',
+    LimitDurationInterval: 'Tempo {lowerBoundClosed}{lowBound}, {highBound}{higherBoundClosed}',
     voltageRange: 'Niveau de tension',
+    VoltageRangeInterval: 'Plage de tension [{lowBound} kV,{highBound} kV]',
 
     Provider: 'Simulateur',
     LimitReduction: 'Abattement des seuils',


### PR DESCRIPTION
* Invert labels and tooltips in the limit reductions table
* Add tooltips on voltage ranges
* Remove excess English capitalization in the limit reductions table of the safety analysis settings