### PR TITLE
Integrate `tsc` with ViteJS

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,9 @@
     "parserOptions": {
         "project": "./tsconfig.json"
     },
+    "env": {
+        "browser": true // allow usage of window.*, navigator.*, etc...
+    },
     "ignorePatterns": [
         // node_modules is implicitly always ignored
         "dist",

--- a/demo/src/app.jsx
+++ b/demo/src/app.jsx
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-/* eslint-disable func-names, no-nested-ternary, no-return-assign, @typescript-eslint/no-unused-vars, no-promise-executor-return, @typescript-eslint/no-unused-expressions, no-alert, no-undef, @typescript-eslint/no-shadow, react/jsx-no-bind, react/prop-types, import/no-extraneous-dependencies */
+/* eslint-disable func-names, no-nested-ternary, no-return-assign, @typescript-eslint/no-unused-vars, no-promise-executor-return, @typescript-eslint/no-unused-expressions, no-alert, @typescript-eslint/no-shadow, react/jsx-no-bind, react/prop-types */
 
 import {
     Box,
@@ -47,6 +47,7 @@ import InputsTab from './InputsTab';
 import { EquipmentSearchDialog } from './equipment-search';
 import { InlineSearch } from './inline-search';
 import {
+    EQUIPMENT_TYPE,
     MultipleSelectionDialog,
     OverflowableText,
     SnackbarProvider,
@@ -103,6 +104,7 @@ import {
     networkModificationsFr,
     logout,
     equipmentStyles,
+    setShowAuthenticationRouterLogin,
 } from '../../src';
 
 const messages = {
@@ -197,7 +199,6 @@ const CustomTreeViewFinder = styled(TreeViewFinder)(TreeViewFinderCustomStylesEm
 function Crasher() {
     const [crash, setCrash] = useState(false);
     if (crash) {
-        // eslint-disable-next-line no-undef
         window.foonotexists.bar();
     }
     return <Button onClick={() => setCrash(true)}>CRASH ME</Button>;
@@ -298,7 +299,6 @@ function PermanentSnackButton() {
 const validateUser = () => {
     // change to false to simulate user unauthorized access
     return new Promise((resolve) => {
-        // eslint-disable-next-line no-undef
         window.setTimeout(() => resolve(true), 500);
     });
 };

--- a/demo/src/index.jsx
+++ b/demo/src/index.jsx
@@ -9,7 +9,6 @@ import { createRoot } from 'react-dom/client';
 
 import App from './app';
 
-// eslint-disable-next-line no-undef
 const container = document.querySelector('#demo');
 const root = createRoot(container);
 root.render(<App />);

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,8 +95,8 @@
                 "ts-node": "^10.9.2",
                 "typescript": "~5.6.3",
                 "vite": "^6.3.6",
+                "vite-plugin-checker": "^0.11.0",
                 "vite-plugin-dts": "^4.5.4",
-                "vite-plugin-eslint": "^1.8.1",
                 "vite-plugin-lib-inject-css": "^2.2.2",
                 "vite-plugin-svgr": "^4.5.0",
                 "yup": "^1.7.0"
@@ -7771,6 +7771,22 @@
                 "node": ">=10"
             }
         },
+        "node_modules/chokidar": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/ci-info": {
             "version": "3.9.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -13939,9 +13955,9 @@
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.2.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
-            "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+            "version": "11.2.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+            "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -14715,6 +14731,20 @@
                 "dezalgo": "^1.0.0",
                 "graceful-fs": "^4.1.2",
                 "once": "^1.3.0"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.18.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/reconnecting-websocket": {
@@ -16470,6 +16500,19 @@
                 "node": ">=4"
             }
         },
+        "node_modules/unicorn-magic": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/universalify": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -16669,6 +16712,114 @@
                 }
             }
         },
+        "node_modules/vite-plugin-checker": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.11.0.tgz",
+            "integrity": "sha512-iUdO9Pl9UIBRPAragwi3as/BXXTtRu4G12L3CMrjx+WVTd9g/MsqNakreib9M/2YRVkhZYiTEwdH2j4Dm0w7lw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "chokidar": "^4.0.3",
+                "npm-run-path": "^6.0.0",
+                "picocolors": "^1.1.1",
+                "picomatch": "^4.0.3",
+                "tiny-invariant": "^1.3.3",
+                "tinyglobby": "^0.2.14",
+                "vscode-uri": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=16.11"
+            },
+            "peerDependencies": {
+                "@biomejs/biome": ">=1.7",
+                "eslint": ">=7",
+                "meow": "^13.2.0",
+                "optionator": "^0.9.4",
+                "oxlint": ">=1",
+                "stylelint": ">=16",
+                "typescript": "*",
+                "vite": ">=5.4.20",
+                "vls": "*",
+                "vti": "*",
+                "vue-tsc": "~2.2.10 || ^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@biomejs/biome": {
+                    "optional": true
+                },
+                "eslint": {
+                    "optional": true
+                },
+                "meow": {
+                    "optional": true
+                },
+                "optionator": {
+                    "optional": true
+                },
+                "oxlint": {
+                    "optional": true
+                },
+                "stylelint": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                },
+                "vls": {
+                    "optional": true
+                },
+                "vti": {
+                    "optional": true
+                },
+                "vue-tsc": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-plugin-checker/node_modules/npm-run-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0",
+                "unicorn-magic": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/vite-plugin-checker/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/vite-plugin-checker/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/vite-plugin-dts": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.5.4.tgz",
@@ -16694,52 +16845,6 @@
                 "vite": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/vite-plugin-eslint": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/vite-plugin-eslint/-/vite-plugin-eslint-1.8.1.tgz",
-            "integrity": "sha512-PqdMf3Y2fLO9FsNPmMX+//2BF5SF8nEWspZdgl4kSt7UvHDRHVVfHvxsD7ULYzZrJDGRxR81Nq7TOFgwMnUang==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@rollup/pluginutils": "^4.2.1",
-                "@types/eslint": "^8.4.5",
-                "rollup": "^2.77.2"
-            },
-            "peerDependencies": {
-                "eslint": ">=7",
-                "vite": ">=2"
-            }
-        },
-        "node_modules/vite-plugin-eslint/node_modules/@rollup/pluginutils": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-            "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "estree-walker": "^2.0.1",
-                "picomatch": "^2.2.2"
-            },
-            "engines": {
-                "node": ">= 8.0.0"
-            }
-        },
-        "node_modules/vite-plugin-eslint/node_modules/rollup": {
-            "version": "2.79.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
-            "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "rollup": "dist/bin/rollup"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
             }
         },
         "node_modules/vite-plugin-lib-inject-css": {

--- a/package.json
+++ b/package.json
@@ -23,14 +23,15 @@
     "scripts": {
         "start": "vite demo/ --config vite.config.ts",
         "start:open": "vite demo/ --config vite.config.ts --open",
-        "build": "tsc && vite build",
-        "build:pack": "tsc && vite build && npm pack",
+        "build": "vite build",
+        "build:pack": "vite build && npm pack",
         "prepublishOnly": "npm run build",
         "test": "jest",
         "test:coverage": "jest --coverage",
         "test:watch": "jest --watch",
         "lint": "eslint . --ext js,mjs,jsx,ts,mts,tsx --max-warnings 0",
         "lint:format": "prettier --check --cache .",
+        "lint:ts": "tsc",
         "licenses-check": "license-checker --summary --excludePrivatePackages --production --onlyAllow \"$( jq -r .onlyAllow[] license-checker-config.json | tr '\n' ';')\" --excludePackages \"$( jq -r .excludePackages[] license-checker-config.json | tr '\n' ';')\""
     },
     "dependencies": {
@@ -139,8 +140,8 @@
         "ts-node": "^10.9.2",
         "typescript": "~5.6.3",
         "vite": "^6.3.6",
+        "vite-plugin-checker": "^0.11.0",
         "vite-plugin-dts": "^4.5.4",
-        "vite-plugin-eslint": "^1.8.1",
         "vite-plugin-lib-inject-css": "^2.2.2",
         "vite-plugin-svgr": "^4.5.0",
         "yup": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "test": "jest",
         "test:coverage": "jest --coverage",
         "test:watch": "jest --watch",
-        "lint": "eslint . --ext js,mjs,jsx,ts,mts,tsx --max-warnings 0",
+        "lint": "eslint . --ext js,mjs,jsx,ts,mts,tsx --report-unused-disable-directives --max-warnings 0",
         "lint:format": "prettier --check --cache .",
         "lint:ts": "tsc",
         "licenses-check": "license-checker --summary --excludePrivatePackages --production --onlyAllow \"$( jq -r .onlyAllow[] license-checker-config.json | tr '\n' ';')\" --excludePackages \"$( jq -r .excludePackages[] license-checker-config.json | tr '\n' ';')\""

--- a/src/components/snackbarProvider/index.ts
+++ b/src/components/snackbarProvider/index.ts
@@ -4,5 +4,4 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-// eslint-disable-next-line import/prefer-default-export
 export * from './SnackbarProvider';

--- a/src/services/study.ts
+++ b/src/services/study.ts
@@ -16,7 +16,6 @@ import { VoltageInitStudyParameters } from '../components/parameters/voltage-ini
 
 const PREFIX_STUDY_QUERIES = `${import.meta.env.VITE_API_GATEWAY}/study`;
 
-// eslint-disable-next-line import/prefer-default-export
 export function exportFilter(studyUuid: UUID, filterUuid?: UUID, token?: string) {
     console.info('get filter export on study root node');
     return backendFetchJson(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,8 +7,7 @@
 
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
-// @ts-expect-error See https://github.com/gxmari007/vite-plugin-eslint/issues/79
-import eslint from 'vite-plugin-eslint';
+import checker from 'vite-plugin-checker';
 import svgr from 'vite-plugin-svgr';
 import { libInjectCss } from 'vite-plugin-lib-inject-css';
 import dts from 'vite-plugin-dts';
@@ -19,9 +18,17 @@ import * as url from 'node:url';
 export default defineConfig((config) => ({
     plugins: [
         react(),
-        eslint({
-            failOnWarning: config.mode !== 'development',
-            lintOnStart: true,
+        checker({
+            overlay: { initialIsOpen: 'error' },
+            typescript: true,
+            eslint: {
+                dev: {
+                    logLevel: config.command === 'serve' ? ['error'] : ['error', 'warning'],
+                },
+                // lintCommand: 'eslint . --ext js,mjs,jsx,ts,mts,tsx --max-warnings 0',
+                lintCommand: 'eslint "./**/*.{js,mjs,jsx,ts,mts,tsx}" --max-warnings 0',
+                watchPath: ['./src', './demo'],
+            },
         }),
         svgr(), // works on every import with the pattern "**/*.svg?react"
         libInjectCss(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,8 +25,8 @@ export default defineConfig((config) => ({
                 dev: {
                     logLevel: config.command === 'serve' ? ['error'] : ['error', 'warning'],
                 },
-                // lintCommand: 'eslint . --ext js,mjs,jsx,ts,mts,tsx --max-warnings 0',
-                lintCommand: 'eslint "./**/*.{js,mjs,jsx,ts,mts,tsx}" --max-warnings 0',
+                lintCommand:
+                    'eslint "./**/*.{js,mjs,jsx,ts,mts,tsx}" --report-unused-disable-directives --max-warnings 0',
                 watchPath: ['./src', './demo'],
             },
         }),


### PR DESCRIPTION
Replace _vite-plugin-eslint_ by _vite-plugin-checker_ to have both `eslint` and `tsc` into the build pipeline of `vite`.

During dev, it show a little hover in bottom left corner, clickable to show the error output, and show in the console. So it don't block the view like before.  
Also the initial runs of ESLint and Typescript are in parallel of the initial build, so no more delay for the build.
<img width="115" height="50" alt="image" src="https://github.com/user-attachments/assets/fa535338-ae3d-4c6b-b162-d1dd724ad7ea" />
<img width="840" height="505" alt="image" src="https://github.com/user-attachments/assets/b9f51a6c-20af-4002-a5b1-a85b0d714194" />


> [!NOTE]
> Another reason of this change is because of how the actual plugin include eslint into the vite process create out-of-memory problems when trying to add Babel plugins.
