### PR TITLE
set isRootNode as optional

### DIFF
--- a/src/components/parameters/common/parameters-edition-dialog-props.ts
+++ b/src/components/parameters/common/parameters-edition-dialog-props.ts
@@ -18,7 +18,7 @@ export interface ParametersEditionDialogProps {
     name: string;
     description: string | null;
     activeDirectory: UUID;
-    isRootNode: boolean;
+    isRootNode?: boolean;
     language?: GsLang;
     user: User | null;
     globalBuildStatus?: BuildStatus;


### PR DESCRIPTION
## PR Summary
- set isRootNode as optional because it is not needed in other computation than sensi and in gridexplore


