### PR TITLE
[FIX] undefined exception in load variation DMC Params

### DIFF
--- a/src/components/parameters/common/parameter-table-field/parameter-table-field.tsx
+++ b/src/components/parameters/common/parameter-table-field/parameter-table-field.tsx
@@ -38,7 +38,7 @@ export function ParameterTableField({
     const { getValues } = useFormContext();
     // This Ref keeps the previous valid row count to optimize whether propagating onChange
     const validRowCountRef = useRef(
-        getValues(name).filter((row: FieldValues) => (isValidRow ? isValidRow(row) : true)).length
+        getValues(name)?.filter((row: FieldValues) => (isValidRow ? isValidRow(row) : true)).length
     );
 
     const newDefaultRowData = useMemo(() => {

--- a/src/components/parameters/dynamic-margin-calculation/loads-variations-parameters.tsx
+++ b/src/components/parameters/dynamic-margin-calculation/loads-variations-parameters.tsx
@@ -140,7 +140,6 @@ export default function LoadsVariationsParameters({ path }: Readonly<{ path: str
                 tooltipProps={{ title: 'DynamicMarginCalculationLoadsVariations' }}
                 columnsDefinition={columnsDefinition}
                 tableHeight={270}
-                disableDragAndDrop
             />
         </Grid>
     );


### PR DESCRIPTION
## PR Summary
Regression from PR https://github.com/gridsuite/commons-ui/pull/1091

1. FIX TypeError: can't access property "filter", c(...) is undefined
2. remove option disableDragAndDrop from previous PR



