### PR TITLE
fix validation message localization in production

### DIFF
--- a/src/components/parameters/dynamic-margin-calculation/loads-variations-parameters.tsx
+++ b/src/components/parameters/dynamic-margin-calculation/loads-variations-parameters.tsx
@@ -31,27 +31,28 @@ import { NAME } from '../../inputs';
 import { ParameterTableField } from '../common/parameter-table-field';
 import { DndColumn, DndColumnType } from '../../dnd-table-v2';
 
-export const formSchema = yup.object().shape({
-    [CALCULATION_TYPE]: yup.string().required(),
-    [ACCURACY]: yup.number().required(),
-    [LOAD_MODELS_RULE]: yup.string().required(),
-    [LOADS_VARIATIONS]: yup.array().of(
-        yup.object().shape({
-            [ID]: yup.string().nullable(), // not shown in form, used to identify a row
-            [LOAD_FILTERS]: yup
-                .array()
-                .of(
-                    yup.object().shape({
-                        [ID]: yup.string().required(),
-                        [NAME]: yup.string().nullable().notRequired(),
-                    })
-                )
-                .min(1),
-            [VARIATION]: yup.number().min(0).required(),
-            [ACTIVE]: yup.boolean().nullable().notRequired(),
-        })
-    ),
-});
+export const getLoadsVariationsFormSchema = () =>
+    yup.object().shape({
+        [CALCULATION_TYPE]: yup.string().required(),
+        [ACCURACY]: yup.number().required(),
+        [LOAD_MODELS_RULE]: yup.string().required(),
+        [LOADS_VARIATIONS]: yup.array().of(
+            yup.object().shape({
+                [ID]: yup.string().nullable(), // not shown in form, used to identify a row
+                [LOAD_FILTERS]: yup
+                    .array()
+                    .of(
+                        yup.object().shape({
+                            [ID]: yup.string().required(),
+                            [NAME]: yup.string().nullable().notRequired(),
+                        })
+                    )
+                    .min(1),
+                [VARIATION]: yup.number().min(0).required(),
+                [ACTIVE]: yup.boolean().nullable().notRequired(),
+            })
+        ),
+    });
 
 export const emptyFormData = {
     [CALCULATION_TYPE]: '',

--- a/src/components/parameters/dynamic-margin-calculation/time-delay-parameters.tsx
+++ b/src/components/parameters/dynamic-margin-calculation/time-delay-parameters.tsx
@@ -17,13 +17,14 @@ import {
 import { ParameterType, SpecificParameterInfos } from '../../../utils';
 import ParameterField from '../common/parameter-field';
 
-export const formSchema = yup.object().shape({
-    [START_TIME]: yup.number().required(),
-    [STOP_TIME]: yup.number().required(),
-    [MARGIN_CALCULATION_START_TIME]: yup.number().required(),
-    [LOAD_INCREASE_START_TIME]: yup.number().required(),
-    [LOAD_INCREASE_STOP_TIME]: yup.number().required(),
-});
+export const getTimeDelayFormSchema = () =>
+    yup.object().shape({
+        [START_TIME]: yup.number().required(),
+        [STOP_TIME]: yup.number().required(),
+        [MARGIN_CALCULATION_START_TIME]: yup.number().required(),
+        [LOAD_INCREASE_START_TIME]: yup.number().required(),
+        [LOAD_INCREASE_STOP_TIME]: yup.number().required(),
+    });
 
 export const emptyFormData = {
     [START_TIME]: 0,

--- a/src/components/parameters/dynamic-margin-calculation/use-dynamic-margin-calculation-parameters-form.ts
+++ b/src/components/parameters/dynamic-margin-calculation/use-dynamic-margin-calculation-parameters-form.ts
@@ -8,10 +8,10 @@
 import { FieldValues } from 'react-hook-form';
 import yup from '../../../utils/yupConfig';
 import { DynamicMarginCalculationParametersInfos } from '../../../utils/types/dynamic-margin-calculation.type';
-import { emptyFormData as timeDelayEmptyFormData, formSchema as timeDelayFormSchema } from './time-delay-parameters';
+import { emptyFormData as timeDelayEmptyFormData, getTimeDelayFormSchema } from './time-delay-parameters';
 import {
     emptyFormData as loadsVariationsEmptyFormData,
-    formSchema as loadsVariationsFormSchema,
+    getLoadsVariationsFormSchema,
 } from './loads-variations-parameters';
 import { ID } from '../../../utils';
 import { PROVIDER } from '../common';
@@ -30,11 +30,12 @@ import {
 import { TabValues } from './dynamic-margin-calculation.type';
 import { UseComputationParametersFormReturn } from '../common/utils';
 
-const formSchema = yup.object().shape({
-    [PROVIDER]: yup.string().required(),
-    [TabValues.TAB_TIME_DELAY]: timeDelayFormSchema,
-    [TabValues.TAB_LOADS_VARIATIONS]: loadsVariationsFormSchema,
-});
+const getFormSchema = () =>
+    yup.object().shape({
+        [PROVIDER]: yup.string().required(),
+        [TabValues.TAB_TIME_DELAY]: getTimeDelayFormSchema(),
+        [TabValues.TAB_LOADS_VARIATIONS]: getLoadsVariationsFormSchema(),
+    });
 
 const emptyFormData = {
     [PROVIDER]: '',
@@ -87,7 +88,7 @@ export function useDynamicMarginCalculationParametersForm(
 ): UseComputationParametersFormReturn {
     return useParametersForm({
         ...props,
-        formSchema,
+        formSchema: getFormSchema(),
         emptyFormData,
         toFormValues,
     });

--- a/src/components/parameters/dynamic-security-analysis/use-dynamic-security-analysis-parameters-form.ts
+++ b/src/components/parameters/dynamic-security-analysis/use-dynamic-security-analysis-parameters-form.ts
@@ -19,31 +19,34 @@ import { UseComputationParametersFormReturn } from '../common/utils';
 import { TabValues } from './dynamic-security-analysis.type';
 import { useParametersForm } from '../common/hook/use-parameters-form';
 
-const scenarioFormSchema = yup
-    .object()
-    .shape({
-        [SCENARIO_DURATION]: yup.number().required(),
-    })
-    .required();
+const getScenarioFormSchema = () =>
+    yup
+        .object()
+        .shape({
+            [SCENARIO_DURATION]: yup.number().required(),
+        })
+        .required();
 
-const contingencyFormSchema = yup.object().shape({
-    [CONTINGENCIES_START_TIME]: yup.number().required(),
-    [CONTINGENCIES_LIST_INFOS]: yup
-        .array()
-        .of(
-            yup.object().shape({
-                [ID]: yup.string().required(),
-                [NAME]: yup.string().required(),
-            })
-        )
-        .required(),
-});
+const getContingencyFormSchema = () =>
+    yup.object().shape({
+        [CONTINGENCIES_START_TIME]: yup.number().required(),
+        [CONTINGENCIES_LIST_INFOS]: yup
+            .array()
+            .of(
+                yup.object().shape({
+                    [ID]: yup.string().required(),
+                    [NAME]: yup.string().required(),
+                })
+            )
+            .required(),
+    });
 
-export const formSchema = yup.object().shape({
-    [PROVIDER]: yup.string().required(),
-    [TabValues.SCENARIO]: scenarioFormSchema,
-    [TabValues.CONTINGENCY]: contingencyFormSchema,
-});
+const getFormSchema = () =>
+    yup.object().shape({
+        [PROVIDER]: yup.string().required(),
+        [TabValues.SCENARIO]: getScenarioFormSchema(),
+        [TabValues.CONTINGENCY]: getContingencyFormSchema(),
+    });
 
 const scenarioEmptyFormData = {
     [SCENARIO_DURATION]: 0,
@@ -91,7 +94,7 @@ export function useDynamicSecurityAnalysisParametersForm(
 ): UseComputationParametersFormReturn {
     return useParametersForm({
         ...props,
-        formSchema,
+        formSchema: getFormSchema(),
         emptyFormData,
         toFormValues,
     });

--- a/src/components/parameters/dynamic-simulation/curve/curve-parameters-utils.ts
+++ b/src/components/parameters/dynamic-simulation/curve/curve-parameters-utils.ts
@@ -7,17 +7,18 @@
 import yup from '../../../../utils/yupConfig';
 import { Curve } from './curve-parameters-constants';
 
-export const curveFormSchema = yup.object().shape({
-    [Curve.CURVES]: yup
-        .array()
-        .of(
-            yup.object().shape({
-                [Curve.EQUIPMENT_ID]: yup.string().required(),
-                [Curve.VARIABLE_ID]: yup.string().required(),
-            })
-        )
-        .nullable(),
-});
+export const getCurveFormSchema = () =>
+    yup.object().shape({
+        [Curve.CURVES]: yup
+            .array()
+            .of(
+                yup.object().shape({
+                    [Curve.EQUIPMENT_ID]: yup.string().required(),
+                    [Curve.VARIABLE_ID]: yup.string().required(),
+                })
+            )
+            .nullable(),
+    });
 
 export const curveEmptyFormData = {
     [Curve.CURVES]: [],

--- a/src/components/parameters/dynamic-simulation/mapping/mapping-parameters-utils.ts
+++ b/src/components/parameters/dynamic-simulation/mapping/mapping-parameters-utils.ts
@@ -7,9 +7,10 @@
 import yup from '../../../../utils/yupConfig';
 import { MAPPING } from './mapping-parameters-constants';
 
-export const mappingFormSchema = yup.object().shape({
-    [MAPPING]: yup.string().required(),
-});
+export const getMappingFormSchema = () =>
+    yup.object().shape({
+        [MAPPING]: yup.string().required(),
+    });
 
 export const mappingEmptyFormData = {
     [MAPPING]: '',

--- a/src/components/parameters/dynamic-simulation/network/network-parameters-utils.ts
+++ b/src/components/parameters/dynamic-simulation/network/network-parameters-utils.ts
@@ -7,28 +7,29 @@
 import { Network } from './network-parameters-constants';
 import yup from '../../../../utils/yupConfig';
 
-export const networkFormSchema = yup.object().shape({
-    [Network.CAPACITOR_NO_RECLOSING_DELAY]: yup.number().required(),
-    [Network.BOUNDARY_LINE_CURRENT_LIMIT_MAX_TIME_OPERATION]: yup.number().required(),
-    [Network.LINE_CURRENT_LIMIT_MAX_TIME_OPERATION]: yup.number().required(),
-    [Network.LOAD_TP]: yup.number().required(),
-    [Network.LOAD_TQ]: yup.number().required(),
-    [Network.LOAD_ALPHA]: yup.number().required(),
-    [Network.LOAD_ALPHA_LONG]: yup.number().required(),
-    [Network.LOAD_BETA]: yup.number().required(),
-    [Network.LOAD_BETA_LONG]: yup.number().required(),
-    [Network.LOAD_IS_CONTROLLABLE]: yup.boolean(),
-    [Network.LOAD_IS_RESTORATIVE]: yup.boolean(),
-    [Network.LOAD_Z_PMAX]: yup.number().required(),
-    [Network.LOAD_Z_QMAX]: yup.number().required(),
-    [Network.REACTANCE_NO_RECLOSING_DELAY]: yup.number().required(),
-    [Network.TRANSFORMER_CURRENT_LIMIT_MAX_TIME_OPERATION]: yup.number().required(),
-    [Network.TRANSFORMER_T1_ST_HT]: yup.number().required(),
-    [Network.TRANSFORMER_T1_ST_THT]: yup.number().required(),
-    [Network.TRANSFORMER_T_NEXT_HT]: yup.number().required(),
-    [Network.TRANSFORMER_T_NEXT_THT]: yup.number().required(),
-    [Network.TRANSFORMER_TO_LV]: yup.number().required(),
-});
+export const getNetworkFormSchema = () =>
+    yup.object().shape({
+        [Network.CAPACITOR_NO_RECLOSING_DELAY]: yup.number().required(),
+        [Network.BOUNDARY_LINE_CURRENT_LIMIT_MAX_TIME_OPERATION]: yup.number().required(),
+        [Network.LINE_CURRENT_LIMIT_MAX_TIME_OPERATION]: yup.number().required(),
+        [Network.LOAD_TP]: yup.number().required(),
+        [Network.LOAD_TQ]: yup.number().required(),
+        [Network.LOAD_ALPHA]: yup.number().required(),
+        [Network.LOAD_ALPHA_LONG]: yup.number().required(),
+        [Network.LOAD_BETA]: yup.number().required(),
+        [Network.LOAD_BETA_LONG]: yup.number().required(),
+        [Network.LOAD_IS_CONTROLLABLE]: yup.boolean(),
+        [Network.LOAD_IS_RESTORATIVE]: yup.boolean(),
+        [Network.LOAD_Z_PMAX]: yup.number().required(),
+        [Network.LOAD_Z_QMAX]: yup.number().required(),
+        [Network.REACTANCE_NO_RECLOSING_DELAY]: yup.number().required(),
+        [Network.TRANSFORMER_CURRENT_LIMIT_MAX_TIME_OPERATION]: yup.number().required(),
+        [Network.TRANSFORMER_T1_ST_HT]: yup.number().required(),
+        [Network.TRANSFORMER_T1_ST_THT]: yup.number().required(),
+        [Network.TRANSFORMER_T_NEXT_HT]: yup.number().required(),
+        [Network.TRANSFORMER_T_NEXT_THT]: yup.number().required(),
+        [Network.TRANSFORMER_TO_LV]: yup.number().required(),
+    });
 
 export const networkEmptyFormData = {
     [Network.CAPACITOR_NO_RECLOSING_DELAY]: 0,

--- a/src/components/parameters/dynamic-simulation/solver/solver-parameters-utils.ts
+++ b/src/components/parameters/dynamic-simulation/solver/solver-parameters-utils.ts
@@ -10,27 +10,28 @@ import { Solver } from './solver-parameters-constants';
 import { getIdaFormSchema } from './ida-solver';
 import { getSimplifiedFormSchema } from './sim-solver';
 
-export const solverFormSchema = yup.object().shape({
-    [Solver.SOLVER]: yup.string().required(),
-    [Solver.SOLVERS]: yup.array().when([Solver.SOLVER], ([solver], schema) =>
-        schema.of(
-            yup.lazy((item) => {
-                const { type } = item;
+export const getSolverFormSchema = () =>
+    yup.object().shape({
+        [Solver.SOLVER]: yup.string().required(),
+        [Solver.SOLVERS]: yup.array().when([Solver.SOLVER], ([solver], schema) =>
+            schema.of(
+                yup.lazy((item) => {
+                    const { type } = item;
 
-                // ignore validation if not current selected solver
-                if (solver !== type) {
-                    return yup.object().default(undefined);
-                }
+                    // ignore validation if not current selected solver
+                    if (solver !== type) {
+                        return yup.object().default(undefined);
+                    }
 
-                // chose the right schema for each type of solver
-                if (type === SolverType.IDA) {
-                    return getIdaFormSchema();
-                }
-                return getSimplifiedFormSchema();
-            })
-        )
-    ),
-});
+                    // chose the right schema for each type of solver
+                    if (type === SolverType.IDA) {
+                        return getIdaFormSchema();
+                    }
+                    return getSimplifiedFormSchema();
+                })
+            )
+        ),
+    });
 
 export const solverEmptyFormData = {
     [Solver.SOLVER]: '',

--- a/src/components/parameters/dynamic-simulation/time-delay/time-delay-parameters-utils.ts
+++ b/src/components/parameters/dynamic-simulation/time-delay/time-delay-parameters-utils.ts
@@ -8,18 +8,19 @@ import yup from '../../../../utils/yupConfig';
 import { TimeDelay } from './time-delay-parameters-constants';
 import { isEmpty } from '../../../../utils/functions';
 
-export const timeDelayFormSchema = yup.object().shape({
-    [TimeDelay.START_TIME]: yup.number().required(),
-    [TimeDelay.STOP_TIME]: yup
-        .number()
-        .required()
-        .when([TimeDelay.START_TIME], ([startTime], schema) => {
-            if (!isEmpty(startTime)) {
-                return schema.min(startTime, 'DynamicSimulationStopTimeMustBeGreaterThanOrEqualToStartTime');
-            }
-            return schema;
-        }),
-});
+export const getTimeDelayFormSchema = () =>
+    yup.object().shape({
+        [TimeDelay.START_TIME]: yup.number().required(),
+        [TimeDelay.STOP_TIME]: yup
+            .number()
+            .required()
+            .when([TimeDelay.START_TIME], ([startTime], schema) => {
+                if (!isEmpty(startTime)) {
+                    return schema.min(startTime, 'DynamicSimulationStopTimeMustBeGreaterThanOrEqualToStartTime');
+                }
+                return schema;
+            }),
+    });
 
 export const timeDelayEmptyFormData = {
     [TimeDelay.START_TIME]: 0,

--- a/src/components/parameters/dynamic-simulation/use-dynamic-simulation-parameters-form.ts
+++ b/src/components/parameters/dynamic-simulation/use-dynamic-simulation-parameters-form.ts
@@ -10,11 +10,11 @@ import { DynamicSimulationParametersInfos, SolverInfos } from '../../../utils/ty
 import { TabValues } from './dynamic-simulation.type';
 import yup from '../../../utils/yupConfig';
 import { PROVIDER } from '../common/constants';
-import { timeDelayEmptyFormData, timeDelayFormSchema } from './time-delay/time-delay-parameters-utils';
-import { solverEmptyFormData, solverFormSchema } from './solver/solver-parameters-utils';
-import { mappingEmptyFormData, mappingFormSchema } from './mapping/mapping-parameters-utils';
-import { networkEmptyFormData, networkFormSchema } from './network/network-parameters-utils';
-import { curveEmptyFormData, curveFormSchema } from './curve/curve-parameters-utils';
+import { timeDelayEmptyFormData, getTimeDelayFormSchema } from './time-delay/time-delay-parameters-utils';
+import { solverEmptyFormData, getSolverFormSchema } from './solver/solver-parameters-utils';
+import { mappingEmptyFormData, getMappingFormSchema } from './mapping/mapping-parameters-utils';
+import { networkEmptyFormData, getNetworkFormSchema } from './network/network-parameters-utils';
+import { curveEmptyFormData, getCurveFormSchema } from './curve/curve-parameters-utils';
 import { ID } from '../../../utils';
 import { TimeDelay } from './time-delay';
 import { Solver } from './solver';
@@ -22,14 +22,15 @@ import { MAPPING } from './mapping';
 import { Curve } from './curve/curve-parameters-constants';
 import { useParametersForm } from '../common/hook/use-parameters-form';
 
-const formSchema = yup.object().shape({
-    [PROVIDER]: yup.string().required(),
-    [TabValues.TAB_TIME_DELAY]: timeDelayFormSchema,
-    [TabValues.TAB_SOLVER]: solverFormSchema,
-    [TabValues.TAB_MAPPING]: mappingFormSchema,
-    [TabValues.TAB_NETWORK]: networkFormSchema,
-    [TabValues.TAB_CURVE]: curveFormSchema,
-});
+const getFormSchema = () =>
+    yup.object().shape({
+        [PROVIDER]: yup.string().required(),
+        [TabValues.TAB_TIME_DELAY]: getTimeDelayFormSchema(),
+        [TabValues.TAB_SOLVER]: getSolverFormSchema(),
+        [TabValues.TAB_MAPPING]: getMappingFormSchema(),
+        [TabValues.TAB_NETWORK]: getNetworkFormSchema(),
+        [TabValues.TAB_CURVE]: getCurveFormSchema(),
+    });
 
 const emptyFormData = {
     [PROVIDER]: '',
@@ -99,7 +100,7 @@ export function useDynamicSimulationParametersForm(
 ): UseComputationParametersFormReturn {
     return useParametersForm({
         ...props,
-        formSchema,
+        formSchema: getFormSchema(),
         emptyFormData,
         toFormValues,
     });

--- a/src/components/parameters/sensi/utils.ts
+++ b/src/components/parameters/sensi/utils.ts
@@ -395,22 +395,24 @@ export const isValidSensiParameterRow = (row: FieldValues) => {
 export const filterSensiParameterRows = (rows?: FieldValues[]) =>
     (rows ?? []).filter((row) => isValidSensiParameterRow(row));
 
-export const formSchema = yup
-    .object()
-    .shape({
-        [PROVIDER]: yup.string().required(),
-        [FLOW_FLOW_SENSITIVITY_VALUE_THRESHOLD]: yup.number().required(),
-        [ANGLE_FLOW_SENSITIVITY_VALUE_THRESHOLD]: yup.number().required(),
-        [FLOW_VOLTAGE_SENSITIVITY_VALUE_THRESHOLD]: yup.number().required(),
-        ...getSensiInjectionsSetFormSchema(),
-        ...getSensiInjectionsFormSchema(),
-        ...getSensiHVDCsFormSchema(),
-        ...getSensiPSTsFormSchema(),
-        ...getSensiNodesFormSchema(),
-    })
-    .required();
-export type SensitivityAnalysisParametersFormSchema = yup.InferType<typeof formSchema>;
+export const getSensiFormSchema = () =>
+    yup
+        .object()
+        .shape({
+            [PROVIDER]: yup.string().required(),
+            [FLOW_FLOW_SENSITIVITY_VALUE_THRESHOLD]: yup.number().required(),
+            [ANGLE_FLOW_SENSITIVITY_VALUE_THRESHOLD]: yup.number().required(),
+            [FLOW_VOLTAGE_SENSITIVITY_VALUE_THRESHOLD]: yup.number().required(),
+            ...getSensiInjectionsSetFormSchema(),
+            ...getSensiInjectionsFormSchema(),
+            ...getSensiHVDCsFormSchema(),
+            ...getSensiPSTsFormSchema(),
+            ...getSensiNodesFormSchema(),
+        })
+        .required();
+
+export type SensitivityAnalysisParametersFormSchema = yup.InferType<ReturnType<typeof getSensiFormSchema>>;
 
 export const getFormSchema = (name: string | null) => {
-    return formSchema.concat(getNameElementEditorSchema(name));
+    return getSensiFormSchema().concat(getNameElementEditorSchema(name));
 };


### PR DESCRIPTION
In production bundles, the order of module execution can vary. We discovered that several Yup schemas were defined as top-level constants. This caused them to be initialized the moment their file was loaded—often before the main application had a chance to call `yup.setLocale`.
Because Yup "bakes" its error messages at the moment of schema creation, these schemas were stuck with default English strings, ignoring the subsequent localization configuration.