### PR TITLE
feat(CustomAgGridTable): restore rowDragEntireRow

### DIFF
--- a/src/components/composite/agGridTable/CustomAgGridTable.tsx
+++ b/src/components/composite/agGridTable/CustomAgGridTable.tsx
@@ -213,6 +213,7 @@ export const CustomAgGridTable = forwardRef<UseFieldArrayReturn<FieldValues, str
                         onGridReady={onGridReady}
                         cacheOverflowSize={10}
                         rowSelection={rowSelection ?? 'multiple'}
+                        rowDragEntireRow
                         onRowDragMove={(e) => move(getIndex(e.node.data), e.overIndex)}
                         detailRowAutoHeight
                         onSelectionChanged={() => {


### PR DESCRIPTION
Restore `rowDragEntireRow` on the `CustomAgGridTable` so the whole row can be used as the drag handle for reordering.