### PR TITLE
feat(CustomAgGridTable): use selection column as row-drag handle

### DIFF
--- a/src/components/composite/agGridTable/CustomAgGridTable.tsx
+++ b/src/components/composite/agGridTable/CustomAgGridTable.tsx
@@ -67,6 +67,14 @@ const style = (customProps: any) => ({
             outlineOffset: '-1px',
             backgroundColor: theme.agGridBackground.color,
         },
+        // The selection column carries the row-drag handle on each row (see selectionColumnDef).
+        // Nudge the row checkbox slightly to the right, and align the header "select all" checkbox.
+        '& .ag-selection-checkbox': {
+            marginLeft: '6px',
+        },
+        '& .ag-header-select-all': {
+            marginLeft: '33px',
+        },
         ...customProps,
     }),
 });
@@ -213,6 +221,7 @@ export const CustomAgGridTable = forwardRef<UseFieldArrayReturn<FieldValues, str
                         onGridReady={onGridReady}
                         cacheOverflowSize={10}
                         rowSelection={rowSelection ?? 'multiple'}
+                        selectionColumnDef={{ rowDrag: true, width: 80, pinned: 'left' }}
                         onRowDragMove={(e) => move(getIndex(e.node.data), e.overIndex)}
                         detailRowAutoHeight
                         onSelectionChanged={() => {

--- a/src/components/composite/filter/explicitNaming/ExplicitNamingFilterForm.tsx
+++ b/src/components/composite/filter/explicitNaming/ExplicitNamingFilterForm.tsx
@@ -129,7 +129,6 @@ export function ExplicitNamingFilterForm({
                 headerName: intl.formatMessage({
                     id: FieldConstants.EQUIPMENT_ID,
                 }),
-                rowDrag: true,
                 field: FieldConstants.EQUIPMENT_ID,
                 editable: true,
                 singleClickEdit: true,


### PR DESCRIPTION
Carry the row-drag handle on the selection column (`selectionColumnDef` with `rowDrag: true`) of the `CustomAgGridTable`, and adjust the checkbox alignment accordingly. The explicit `rowDrag` on the equipment-id column of `ExplicitNamingFilterForm` is removed since dragging is now handled by the selection column.