### PR TITLE
chore: sort busbar sections in VoltageLevelModificationForm

### DIFF
--- a/src/features/network-modifications/common/measurements/BusbarSectionVoltageMeasurementsForm.tsx
+++ b/src/features/network-modifications/common/measurements/BusbarSectionVoltageMeasurementsForm.tsx
@@ -11,6 +11,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { FieldConstants, VoltageAdornment } from '../../../../utils';
 import { MeasurementInfo } from './measurement.type';
 import { CheckboxNullableInput, FloatInput } from '../../../../components';
+import type { BbsMeasurementItem } from '../../voltageLevel/modification/voltageLevelModification.utils';
 
 const BUSBAR_SECTION_V_MEASUREMENTS = 'busbarSectionVMeasurements';
 
@@ -26,8 +27,15 @@ interface BusbarSectionVoltageMeasurementsFormProps {
 export function BusbarSectionVoltageMeasurementsForm({
     busbarSections,
 }: Readonly<BusbarSectionVoltageMeasurementsFormProps>) {
-    const { fields } = useFieldArray({ name: BUSBAR_SECTION_V_MEASUREMENTS });
+    const { fields } = useFieldArray<Record<typeof BUSBAR_SECTION_V_MEASUREMENTS, BbsMeasurementItem[]>>({
+        name: BUSBAR_SECTION_V_MEASUREMENTS,
+    });
     const intl = useIntl();
+
+    // Keep busbar sections sorted
+    const sortedFields = fields
+        .map((field, i) => ({ ...field, originalIndex: i }))
+        .sort((a, b) => a.busbarSectionId.localeCompare(b.busbarSectionId));
 
     return (
         <Grid container direction="column" spacing={1}>
@@ -36,8 +44,8 @@ export function BusbarSectionVoltageMeasurementsForm({
                     <FormattedMessage id="NoBusbarSectionFound" />
                 </Grid>
             )}
-            {fields.map((field, i) => {
-                const bbsId = (field as any).busbarSectionId as string;
+            {sortedFields.map((field) => {
+                const { busbarSectionId: bbsId, originalIndex } = field;
                 const networkBbs = busbarSections.find((b) => b.id === bbsId);
                 const previousValue = networkBbs?.measurementV?.value ?? undefined;
                 const validity = networkBbs?.measurementV?.validity;
@@ -52,7 +60,7 @@ export function BusbarSectionVoltageMeasurementsForm({
                             <Grid size={3}>{bbsId}</Grid>
                             <Grid size={4}>
                                 <FloatInput
-                                    name={`${BUSBAR_SECTION_V_MEASUREMENTS}.${i}.${FieldConstants.VALUE}`}
+                                    name={`${BUSBAR_SECTION_V_MEASUREMENTS}.${originalIndex}.${FieldConstants.VALUE}`}
                                     label="VoltageText"
                                     adornment={VoltageAdornment}
                                     previousValue={previousValue}
@@ -61,7 +69,7 @@ export function BusbarSectionVoltageMeasurementsForm({
                             </Grid>
                             <Grid size={3}>
                                 <CheckboxNullableInput
-                                    name={`${BUSBAR_SECTION_V_MEASUREMENTS}.${i}.${FieldConstants.VALIDITY}`}
+                                    name={`${BUSBAR_SECTION_V_MEASUREMENTS}.${originalIndex}.${FieldConstants.VALIDITY}`}
                                     label="ValidMeasurement"
                                     previousValue={previousValidity}
                                 />

--- a/src/features/network-modifications/common/measurements/BusbarSectionVoltageMeasurementsForm.tsx
+++ b/src/features/network-modifications/common/measurements/BusbarSectionVoltageMeasurementsForm.tsx
@@ -9,9 +9,8 @@ import { useFieldArray } from 'react-hook-form';
 import { Grid2 as Grid } from '@mui/material';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { FieldConstants, VoltageAdornment } from '../../../../utils';
-import { MeasurementInfo } from './measurement.type';
+import { BbsMeasurementItem, MeasurementInfo } from './measurement.type';
 import { CheckboxNullableInput, FloatInput } from '../../../../components';
-import type { BbsMeasurementItem } from '../../voltageLevel/modification/voltageLevelModification.utils';
 
 const BUSBAR_SECTION_V_MEASUREMENTS = 'busbarSectionVMeasurements';
 
@@ -32,7 +31,6 @@ export function BusbarSectionVoltageMeasurementsForm({
     });
     const intl = useIntl();
 
-    // Keep busbar sections sorted
     const sortedFields = fields
         .map((field, i) => ({ ...field, originalIndex: i }))
         .sort((a, b) => a.busbarSectionId.localeCompare(b.busbarSectionId));

--- a/src/features/network-modifications/common/measurements/measurement.type.ts
+++ b/src/features/network-modifications/common/measurements/measurement.type.ts
@@ -20,3 +20,9 @@ export interface MeasurementProps {
     field: FieldType;
     measurement?: MeasurementInfo;
 }
+
+export type BbsMeasurementItem = {
+    busbarSectionId: string;
+    value: number | null;
+    validity: boolean | null;
+};

--- a/src/features/network-modifications/voltageLevel/modification/voltageLevelModification.utils.ts
+++ b/src/features/network-modifications/voltageLevel/modification/voltageLevelModification.utils.ts
@@ -15,6 +15,7 @@ import { convertInputValue, convertOutputValue } from '../../../../utils/convers
 import { FieldConstants, ModificationType, sanitizeString, toModificationOperation } from '../../../../utils';
 import { FieldType } from '../../../../utils/types/fieldType';
 import { VoltageLevelModificationDto } from './voltageLevelModification.types';
+import { BbsMeasurementItem } from '../../common';
 
 export const voltageLevelModificationFormSchema = object()
     .shape({
@@ -109,12 +110,6 @@ export const voltageLevelModificationWithMeasurementsFormSchema = voltageLevelMo
         busbarSectionVMeasurements: array().of(bbsMeasurementItemSchema).nullable().defined(),
     })
 );
-
-export type BbsMeasurementItem = {
-    busbarSectionId: string;
-    value: number | null;
-    validity: boolean | null;
-};
 
 export type VoltageLevelModificationWithMeasurementsFormData = VoltageLevelModificationFormData & {
     busbarSectionVMeasurements: BbsMeasurementItem[] | null;


### PR DESCRIPTION
## PR Summary
Keep busbar sections sorted by id in voltageLevel modification form



