### PR TITLE
fix(explicit-naming): force column cell data types for CSV import

### DIFF
--- a/src/components/composite/filter/explicitNaming/ExplicitNamingFilterForm.tsx
+++ b/src/components/composite/filter/explicitNaming/ExplicitNamingFilterForm.tsx
@@ -128,6 +128,8 @@ export function ExplicitNamingFilterForm({
                     id: FieldConstants.EQUIPMENT_ID,
                 }),
                 field: FieldConstants.EQUIPMENT_ID,
+                // force the data type instead of letting AG Grid infer it from the (CSV) cell values
+                cellDataType: 'text',
                 editable: true,
                 singleClickEdit: true,
                 flex: 1,
@@ -138,6 +140,8 @@ export function ExplicitNamingFilterForm({
             newColumnDefs.push({
                 headerName: intl.formatMessage({ id: DISTRIBUTION_KEY }),
                 field: DISTRIBUTION_KEY,
+                // force the data type instead of letting AG Grid infer it from the (CSV) cell values
+                cellDataType: 'number',
                 editable: true,
                 singleClickEdit: true,
                 cellEditor: NumericEditor,


### PR DESCRIPTION
## Summary

The explicit naming filter table imports CSV data into an AG Grid. The columns did not declare a `cellDataType`, so AG Grid inferred each column's type from the cell values. When the imported CSV provides unexpected values, the inferred type is wrong and the column is rendered/edited as the wrong data type.

Force the `cellDataType` explicitly instead of relying on inference:
- `EQUIPMENT_ID` → `text`
- `DISTRIBUTION_KEY` → `number`