### PR TITLE
Fix post sort rows for SA NmK results "violations -> contingencies"

### DIFF
--- a/src/features/results/securityanalysis/utils.ts
+++ b/src/features/results/securityanalysis/utils.ts
@@ -189,7 +189,7 @@ export const handlePostSortRows =
         });
 
         agGridRows.forEach((row) => {
-            if (isContingency && !row.data.linkedElementId && !row.data[idField]) {
+            if (isContingency && !row.data.linkedElementId == null && !row.data[idField]) {
                 mappedRows.get('contingencies')!.push(row);
             } else if (row.data[idField] == null) {
                 const group = mappedRows.get(row.data.linkedElementId);

--- a/src/features/results/securityanalysis/utils.ts
+++ b/src/features/results/securityanalysis/utils.ts
@@ -189,7 +189,7 @@ export const handlePostSortRows =
         });
 
         agGridRows.forEach((row) => {
-            if (isContingency && !row.data.linkedElementId == null && !row.data[idField]) {
+            if (isContingency && row.data.linkedElementId == null && !row.data[idField]) {
                 mappedRows.get('contingencies')!.push(row);
             } else if (row.data[idField] == null) {
                 const group = mappedRows.get(row.data.linkedElementId);


### PR DESCRIPTION
## PR Summary
For first children of the list, linkedElementId was equal to 0
Which was considered falsy when checked the previous way



