### PR TITLE
Clear field-level table error when a cell is edited

### DIFF
--- a/src/components/composite/agGridTable/CustomAgGridTable.tsx
+++ b/src/components/composite/agGridTable/CustomAgGridTable.tsx
@@ -108,7 +108,7 @@ export const CustomAgGridTable = forwardRef<UseFieldArrayReturn<FieldValues, str
         const [newRowAdded, setNewRowAdded] = useState(false);
         const [isSortApplied, setIsSortApplied] = useState(false);
 
-        const { control, getValues, watch } = useFormContext();
+        const { control, getValues, watch, clearErrors } = useFormContext();
         const useFieldArrayOutput = useFieldArray({
             control,
             name,
@@ -203,8 +203,12 @@ export const CustomAgGridTable = forwardRef<UseFieldArrayReturn<FieldValues, str
                     return;
                 }
                 update(rowIndex, event.data);
+                // Editing a cell clears any field-level error set on the table (e.g. a CSV import
+                // validation error), so the user can recover and submit after correcting a value.
+                // TODO remove when yup will be set up for tabular form
+                clearErrors(name);
             },
-            [getIndex, update]
+            [getIndex, update, clearErrors, name]
         );
 
         const onSortChanged = useCallback((event: SortChangedEvent) => {


### PR DESCRIPTION
A field-level error set on a `CustomAgGridTable` (typically a CSV import validation error) was never cleared once set, leaving the hosting form's submit button disabled with no way to recover.

This clears the table's field-level error in `onCellEditingStopped`, so editing any cell lets the user correct an offending value and submit again. Forms whose submit button does not depend on the table error are unaffected, and their resolver re-derives the error on the next validation.