### PR TITLE
[FIX] LF, SA, SENSI, SC, NETWORK, PCC, VL params dialogs crashed or not stable

### DIFF
--- a/src/features/parameters/dynamic-simulation/curve/curve-parameters.type.ts
+++ b/src/features/parameters/dynamic-simulation/curve/curve-parameters.type.ts
@@ -1,6 +1,0 @@
-/**
- * Copyright (c) 2023, RTE (http://www.rte-france.com)
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */

--- a/src/features/parameters/loadflow/load-flow-parameters-dialog.tsx
+++ b/src/features/parameters/loadflow/load-flow-parameters-dialog.tsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { Grid2 as Grid } from '@mui/material';
+import { Grid2 as Grid, LinearProgress } from '@mui/material';
 import { CustomMuiDialog } from '../../../components/ui/dialogs';
 import { ParametersEditionDialogProps } from '../common';
 import {
@@ -78,7 +78,11 @@ export function LoadFlowParametersEditionDialog({
                         elementType={ElementType.LOADFLOW_PARAMETERS}
                     />
                 </Grid>
-                <LoadFlowParametersForm loadflowMethods={loadflowMethods} />
+                {loadflowMethods.paramsLoaded ? (
+                    <LoadFlowParametersForm loadflowMethods={loadflowMethods} />
+                ) : (
+                    <LinearProgress />
+                )}
             </LoadFlowProvider>
         </CustomMuiDialog>
     );

--- a/src/features/parameters/network-visualizations/network-visualizations-parameters-dialog.tsx
+++ b/src/features/parameters/network-visualizations/network-visualizations-parameters-dialog.tsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { Grid2 as Grid } from '@mui/material';
+import { Grid2 as Grid, LinearProgress } from '@mui/material';
 import { CustomMuiDialog } from '../../../components/ui/dialogs';
 import { ElementType } from '../../../utils';
 import { NetworkVisualizationParametersForm } from './network-visualizations-form';
@@ -63,7 +63,11 @@ export function NetworkVisualizationsParametersEditionDialog({
                     elementType={ElementType.NETWORK_VISUALIZATIONS_PARAMETERS}
                 />
             </Grid>
-            <NetworkVisualizationParametersForm userProfile={userProfile} networkVisuMethods={networkVisuMethods} />
+            {networkVisuMethods.paramsLoading ? (
+                <LinearProgress />
+            ) : (
+                <NetworkVisualizationParametersForm userProfile={userProfile} networkVisuMethods={networkVisuMethods} />
+            )}
         </CustomMuiDialog>
     );
 }

--- a/src/features/parameters/pcc-min/pcc-min-parameters-dialog.tsx
+++ b/src/features/parameters/pcc-min/pcc-min-parameters-dialog.tsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { Grid2 as Grid } from '@mui/material';
+import { Grid2 as Grid, LinearProgress } from '@mui/material';
 import { CustomMuiDialog } from '../../../components/ui/dialogs';
 import { ElementType } from '../../../utils';
 import { NameElementEditorForm } from '../common/name-element-editor';
@@ -62,7 +62,7 @@ export function PccMinParametersEditionDialog({
                     elementType={ElementType.PCC_MIN_PARAMETERS}
                 />
             </Grid>
-            <PccMinParametersForm />
+            {pccMinMethods.paramsLoading ? <LinearProgress /> : <PccMinParametersForm />}
         </CustomMuiDialog>
     );
 }

--- a/src/features/parameters/security-analysis/security-analysis-parameters-dialog.tsx
+++ b/src/features/parameters/security-analysis/security-analysis-parameters-dialog.tsx
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { Grid2 as Grid } from '@mui/material';
+import { Grid2 as Grid, LinearProgress } from '@mui/material';
 import { OptionalServicesStatus, useParametersBackend } from '../../../hooks';
 import { useSecurityAnalysisParametersForm } from './use-security-analysis-parameters-form';
 import { ParametersEditionDialogProps } from '../common';
@@ -76,11 +76,15 @@ export function SecurityAnalysisParametersDialog({
                     elementType={ElementType.LOADFLOW_PARAMETERS}
                 />
             </Grid>
-            <SecurityAnalysisParametersForm
-                securityAnalysisMethods={securityAnalysisMethods}
-                showContingencyCount={false}
-                isDeveloperMode={isDeveloperMode}
-            />
+            {securityAnalysisMethods.paramsFormInitialized ? (
+                <SecurityAnalysisParametersForm
+                    securityAnalysisMethods={securityAnalysisMethods}
+                    showContingencyCount={false}
+                    isDeveloperMode={isDeveloperMode}
+                />
+            ) : (
+                <LinearProgress />
+            )}
         </CustomMuiDialog>
     );
 }

--- a/src/features/parameters/sensi/sensitivity-analysis-parameters-dialog.tsx
+++ b/src/features/parameters/sensi/sensitivity-analysis-parameters-dialog.tsx
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-import { Grid2 as Grid } from '@mui/material';
+import { Grid2 as Grid, LinearProgress } from '@mui/material';
 import { ParametersEditionDialogProps } from '../common';
 import { OptionalServicesStatus, useParametersBackend } from '../../../hooks';
 import {
@@ -81,12 +81,16 @@ export function SensitivityAnalysisParametersDialog({
                     elementType={ElementType.SENSITIVITY_PARAMETERS}
                 />
             </Grid>
-            <SensitivityAnalysisParametersForm
-                sensitivityAnalysisMethods={sensitivityAnalysisMethods}
-                isDeveloperMode={isDeveloperMode}
-                isRootNode={isRootNode}
-                globalBuildStatus={globalBuildStatus}
-            />
+            {sensitivityAnalysisMethods.paramsFormInitialized ? (
+                <SensitivityAnalysisParametersForm
+                    sensitivityAnalysisMethods={sensitivityAnalysisMethods}
+                    isDeveloperMode={isDeveloperMode}
+                    isRootNode={isRootNode}
+                    globalBuildStatus={globalBuildStatus}
+                />
+            ) : (
+                <LinearProgress />
+            )}
         </CustomMuiDialog>
     );
 }

--- a/src/features/parameters/short-circuit/short-circuit-parameters-dialog.tsx
+++ b/src/features/parameters/short-circuit/short-circuit-parameters-dialog.tsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { Grid2 as Grid } from '@mui/material';
+import { Grid2 as Grid, LinearProgress } from '@mui/material';
 import { CustomMuiDialog } from '../../../components/ui/dialogs';
 import { ComputingType, ElementType } from '../../../utils';
 import { NameElementEditorForm } from '../common/name-element-editor';
@@ -77,7 +77,11 @@ export function ShortCircuitParametersEditionDialog({
                     elementType={ElementType.SHORT_CIRCUIT_PARAMETERS}
                 />
             </Grid>
-            <ShortCircuitParametersForm shortCircuitMethods={shortCircuitMethods} />
+            {shortCircuitMethods.paramsLoaded ? (
+                <ShortCircuitParametersForm shortCircuitMethods={shortCircuitMethods} />
+            ) : (
+                <LinearProgress />
+            )}
         </CustomMuiDialog>
     );
 }

--- a/src/features/parameters/voltage-init/voltage-init-parameters-dialog.tsx
+++ b/src/features/parameters/voltage-init/voltage-init-parameters-dialog.tsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { Grid2 as Grid } from '@mui/material';
+import { Grid2 as Grid, LinearProgress } from '@mui/material';
 import { CustomMuiDialog } from '../../../components/ui/dialogs';
 import { ElementType } from '../../../utils';
 import { NameElementEditorForm } from '../common/name-element-editor';
@@ -62,7 +62,11 @@ export function VoltageInitParametersEditionDialog({
                     elementType={ElementType.VOLTAGE_INIT_PARAMETERS}
                 />
             </Grid>
-            <VoltageInitParametersForm voltageInitMethods={voltageInitMethods} />
+            {voltageInitMethods.paramsLoading ? (
+                <LinearProgress />
+            ) : (
+                <VoltageInitParametersForm voltageInitMethods={voltageInitMethods} />
+            )}
         </CustomMuiDialog>
     );
 }


### PR DESCRIPTION
## PR Summary

- Form should not be rendered before params loaded. There are some atomic input components may be not stable (e.g. autocomplete) when value/options is undefined.
- Bug only in explore which has not yet protect by checking loading or not. This has beeen done in study in the parameter layout, see https://github.com/gridsuite/commons-ui/blob/main/src/features/parameters/common/parameter-layout/parameter-layout.tsx#L121



