### PR TITLE
feat: expose the write permission on shared modifications

### DIFF
--- a/src/components/ui/dialogs/descriptionModificationDialog/DescriptionModificationDialog.tsx
+++ b/src/components/ui/dialogs/descriptionModificationDialog/DescriptionModificationDialog.tsx
@@ -23,6 +23,7 @@ export interface DescriptionModificationDialogProps {
     onClose: () => void;
     updateElement?: (data: Record<string, string>) => Promise<Response>;
     updateForm?: (data: Record<string, string>) => void;
+    disabledSave?: boolean;
 }
 
 const schema = yup.object().shape({
@@ -36,6 +37,7 @@ export function DescriptionModificationDialog({
     onClose,
     updateElement,
     updateForm,
+    disabledSave,
 }: Readonly<DescriptionModificationDialogProps>) {
     const { snackError } = useSnackMessage();
 
@@ -78,6 +80,7 @@ export function DescriptionModificationDialog({
             onSave={onSubmit}
             formContext={{ ...methods, validationSchema: schema, removeOptional: true }}
             titleId="description"
+            disabledSave={disabledSave}
         >
             <Box paddingTop={1}>
                 <ExpandingTextField

--- a/src/features/network-modification-table/index.ts
+++ b/src/features/network-modification-table/index.ts
@@ -9,6 +9,7 @@ export * from './network-modification-table-styles';
 export * from './columns-definition';
 export * from './network-modifications-table';
 export * from './use-modifications-drag-and-drop';
+export * from './use-shared-modifications-permissions';
 export * from './renderers';
 export * from './row';
 export * from './utils';

--- a/src/features/network-modification-table/network-modifications-table.tsx
+++ b/src/features/network-modification-table/network-modifications-table.tsx
@@ -35,6 +35,7 @@ import { AUTO_EXTENSIBLE_COLUMNS } from './columns-definition';
 import { useModificationsDragAndDrop } from './use-modifications-drag-and-drop';
 import { useModificationsSelection } from './use-modifications-selection';
 import {
+    collectLockedNestedModificationUuids,
     fetchSubModificationsForExpandedRows,
     findAllLoadedCompositeModifications,
     findDepth,
@@ -52,7 +53,11 @@ interface NetworkModificationsTableProps extends Omit<NetworkModificationEditorN
     isRowDragDisabled?: boolean;
     onRowDragStart: () => void;
     onRowDragEnd: () => void;
-    onSelectedRowsChange: (selectedRows: ComposedModificationMetadata[], isAssemblyDepthExceeded: boolean) => void;
+    onSelectedRowsChange: (
+        selectedRows: ComposedModificationMetadata[],
+        isAssemblyDepthExceeded: boolean,
+        containsLockedModification: boolean
+    ) => void;
     columns: ColumnDef<ComposedModificationMetadata>[];
     highlightedModificationUuid: UUID | null;
     modificationUuidsToReset?: UUID[]; // those modifications are unselected and unexpanded
@@ -64,6 +69,7 @@ interface NetworkModificationsTableProps extends Omit<NetworkModificationEditorN
     modificationsToExclude?: ExcludedNetworkModifications[];
     setModificationsToExclude?: Dispatch<SetStateAction<ExcludedNetworkModifications[]>>;
     isDisabled?: boolean;
+    readOnlySharedModificationUuids?: Set<UUID>;
 }
 
 export function NetworkModificationsTable({
@@ -84,6 +90,7 @@ export function NetworkModificationsTable({
     modificationsToExclude,
     setModificationsToExclude,
     isDisabled = false,
+    readOnlySharedModificationUuids,
     isImpactedByNotification,
     notificationMessageId,
     isFetchingModifications,
@@ -105,6 +112,20 @@ export function NetworkModificationsTable({
         composedModificationsRef.current = composedModifications;
     }, [composedModifications]);
 
+    // Everything nested inside a shared modification the user can't write into. Kept in a ref as well, so that
+    // handleRowSelected can read it without being recreated every time the tree changes.
+    const lockedNestedModificationUuids = useMemo(
+        () =>
+            readOnlySharedModificationUuids?.size
+                ? collectLockedNestedModificationUuids(readOnlySharedModificationUuids, composedModifications)
+                : undefined,
+        [readOnlySharedModificationUuids, composedModifications]
+    );
+    const lockedNestedModificationUuidsRef = useRef(lockedNestedModificationUuids);
+    useEffect(() => {
+        lockedNestedModificationUuidsRef.current = lockedNestedModificationUuids;
+    }, [lockedNestedModificationUuids]);
+
     // refs are kept for the "event" props to prevent retriggering the associated useEffects
     const modificationToEditLabelRef = useRef(modificationToEditLabel);
     useEffect(() => {
@@ -125,7 +146,10 @@ export function NetworkModificationsTable({
 
     const handleRowSelected = useCallback(
         (selectedRows: ComposedModificationMetadata[]) => {
-            onSelectedRowsChange(selectedRows, isAssemblyDepthExceeded(selectedRows));
+            const containsLockedModification = selectedRows.some((row) =>
+                lockedNestedModificationUuidsRef.current?.has(row.uuid)
+            );
+            onSelectedRowsChange(selectedRows, isAssemblyDepthExceeded(selectedRows), containsLockedModification);
         },
         [onSelectedRowsChange, isAssemblyDepthExceeded]
     );
@@ -203,6 +227,10 @@ export function NetworkModificationsTable({
                 isRowDragDisabled,
                 modificationToEditLabel: modificationToEditLabelRef,
             },
+            permissions: {
+                readOnlySharedModificationUuids,
+                lockedNestedModificationUuids,
+            },
             status: {
                 isImpactedByNotification,
                 notificationMessageId,
@@ -223,6 +251,8 @@ export function NetworkModificationsTable({
             handleRowSelected,
             modificationToEditLabelRef,
             isRowDragDisabled,
+            readOnlySharedModificationUuids,
+            lockedNestedModificationUuids,
             isImpactedByNotification,
             notificationMessageId,
             isFetchingModifications,
@@ -367,6 +397,9 @@ export function NetworkModificationsTable({
                                                 handleCellClick={handleCellClick}
                                                 isRowDragDisabled={isRowDragDisabled}
                                                 highlightedModificationUuid={highlightedModificationUuid}
+                                                isFormOpeningLocked={lockedNestedModificationUuids?.has(
+                                                    row.original.uuid
+                                                )}
                                             />
                                         );
                                     })}

--- a/src/features/network-modification-table/renderers/cell-renderers.tsx
+++ b/src/features/network-modification-table/renderers/cell-renderers.tsx
@@ -18,6 +18,7 @@ import { DescriptionCell } from './description-cell';
 import { SwitchCell } from './switch-cell';
 import { RootNetworkChipCell } from './root-network-chip-cell';
 import { createRootNetworkChipCellSx, networkModificationTableStyles } from '../network-modification-table-styles';
+import { isModificationEditLocked } from '../utils';
 import { ComposedModificationMetadata } from '../../../utils';
 
 /**
@@ -32,6 +33,16 @@ import { ComposedModificationMetadata } from '../../../utils';
 
 type CCtx = CellContext<ComposedModificationMetadata, unknown>;
 type HCtx = HeaderContext<ComposedModificationMetadata, unknown>;
+
+/** True when the row can't be edited because of the permissions on the shared modification holding it. */
+function isRowEditLocked({ row, table }: CCtx): boolean {
+    const permissions = table.options.meta?.permissions;
+    return isModificationEditLocked(
+        row.original.uuid,
+        permissions?.readOnlySharedModificationUuids,
+        permissions?.lockedNestedModificationUuids
+    );
+}
 
 export function DragHandleRenderer({ table }: CCtx) {
     return <DragHandleCell isRowDragDisabled={table.options.meta?.interaction.isRowDragDisabled ?? false} />;
@@ -58,11 +69,20 @@ export function NameHeaderRenderer({ table }: HCtx) {
     );
 }
 
-export function NameCellRenderer({ row, table, column }: CCtx) {
-    return <NameCell row={row} table={table} onChange={column.columnDef.meta?.onChange} />;
+export function NameCellRenderer(context: CCtx) {
+    const { row, table, column } = context;
+    return (
+        <NameCell
+            row={row}
+            table={table}
+            onChange={column.columnDef.meta?.onChange}
+            isRenameDisabled={isRowEditLocked(context)}
+        />
+    );
 }
 
-export function DescriptionCellRenderer({ row, table }: CCtx) {
+export function DescriptionCellRenderer(context: CCtx) {
+    const { row, table } = context;
     const { meta } = table.options;
     return (
         <DescriptionCell
@@ -70,18 +90,20 @@ export function DescriptionCellRenderer({ row, table }: CCtx) {
             studyUuid={meta?.context.studyUuid ?? null}
             currentNodeId={meta?.context.currentNodeId}
             isDisabled={meta?.status.isDisabled}
+            isSaveDisabled={isRowEditLocked(context)}
         />
     );
 }
 
-export function SwitchCellRenderer({ row, table }: CCtx) {
+export function SwitchCellRenderer(context: CCtx) {
+    const { row, table } = context;
     const { meta } = table.options;
     return (
         <SwitchCell
             data={row.original}
             studyUuid={meta?.context.studyUuid ?? null}
             currentNodeId={meta?.context.currentNodeId}
-            isDisabled={meta?.status.isDisabled}
+            isDisabled={meta?.status.isDisabled || isRowEditLocked(context)}
         />
     );
 }
@@ -108,7 +130,8 @@ export function RootNetworkHeaderRenderer({ column, table }: HCtx) {
     );
 }
 
-export function RootNetworkCellRenderer({ row, column, table }: CCtx) {
+export function RootNetworkCellRenderer(context: CCtx) {
+    const { row, column, table } = context;
     const { meta } = table.options;
     // `column.id` is the rootNetworkUuid (set in createRootNetworksColumns).
     const rootNetwork = meta?.context.rootNetworks?.find((r) => r.rootNetworkUuid === column.id);
@@ -124,7 +147,7 @@ export function RootNetworkCellRenderer({ row, column, table }: CCtx) {
                 rootNetwork={rootNetwork}
                 modificationsToExclude={meta.modifications.toExclude}
                 setModificationsToExclude={meta.modifications.setToExclude}
-                isDisabled={meta?.status.isDisabled}
+                isDisabled={meta?.status.isDisabled || isRowEditLocked(context)}
             />
         </Box>
     );

--- a/src/features/network-modification-table/renderers/description-cell.tsx
+++ b/src/features/network-modification-table/renderers/description-cell.tsx
@@ -20,10 +20,12 @@ export interface DescriptionCellProps {
     studyUuid: UUID | null;
     currentNodeId?: UUID;
     isDisabled?: boolean;
+    // the dialog stays reachable, only its validation is denied
+    isSaveDisabled?: boolean;
 }
 
 export function DescriptionCell(props: DescriptionCellProps) {
-    const { data, studyUuid, currentNodeId, isDisabled = false } = props;
+    const { data, studyUuid, currentNodeId, isDisabled = false, isSaveDisabled = false } = props;
     const [isLoading, setIsLoading] = useState(false);
     const [openDescModificationDialog, setOpenDescModificationDialog] = useState(false);
 
@@ -60,6 +62,7 @@ export function DescriptionCell(props: DescriptionCellProps) {
                     description={description ?? ''}
                     onClose={handleDescDialogClose}
                     updateElement={updateModification}
+                    disabledSave={isSaveDisabled}
                 />
             )}
             <Tooltip title={description ?? <FormattedMessage id="addDescription" />} arrow enterDelay={250}>

--- a/src/features/network-modification-table/renderers/name-cell.tsx
+++ b/src/features/network-modification-table/renderers/name-cell.tsx
@@ -37,9 +37,10 @@ interface NameCellProps {
     row: Row<ComposedModificationMetadata>;
     table: Table<ComposedModificationMetadata>;
     onChange?: (modification: ComposedModificationMetadata, newValue: string) => Promise<unknown>;
+    isRenameDisabled?: boolean;
 }
 
-export function NameCell({ row, table, onChange }: Readonly<NameCellProps>) {
+export function NameCell({ row, table, onChange, isRenameDisabled = false }: Readonly<NameCellProps>) {
     const { meta } = table.options;
     const intl = useIntl();
     const theme = useTheme();
@@ -49,6 +50,7 @@ export function NameCell({ row, table, onChange }: Readonly<NameCellProps>) {
     const { depth } = row;
 
     const isComposite = isCompositeModification(row.original);
+    const isRenamable = isComposite && !isRenameDisabled;
 
     const getModificationLabel = useCallback(
         (modification: ComposedModificationMetadata, formatBold: boolean = true) => {
@@ -156,13 +158,13 @@ export function NameCell({ row, table, onChange }: Readonly<NameCellProps>) {
     // triggers composite name editing from outside the component
     useEffect(() => {
         const modificationToEditLabel = meta?.interaction.modificationToEditLabel.current;
-        if (isComposite && !isEditingRef.current && modificationToEditLabel === row.original.uuid) {
+        if (isRenamable && !isEditingRef.current && modificationToEditLabel === row.original.uuid) {
             beginEditingName(defaultCompositeName);
             if (meta) {
                 meta.interaction.modificationToEditLabel.current = null;
             }
         }
-    }, [meta, defaultCompositeName, isComposite, row.original.uuid, beginEditingName]);
+    }, [meta, defaultCompositeName, isRenamable, row.original.uuid, beginEditingName]);
 
     const handleLabelClick = useCallback(
         (e: React.MouseEvent) => {
@@ -195,7 +197,7 @@ export function NameCell({ row, table, onChange }: Readonly<NameCellProps>) {
             <DepthBox key={i} firstLevel={i === 0} displayAsFolder={isComposite && i === depthLevelCount - 1} />
         ));
     };
-    const compositeReadModeProps = isComposite
+    const renamableModeProps = isRenamable
         ? {
               ref: labelRef,
               onClick: handleLabelClick,
@@ -272,11 +274,11 @@ export function NameCell({ row, table, onChange }: Readonly<NameCellProps>) {
                         /* Read mode */
                         <CustomTooltip disableFocusListener disableTouchListener title={label}>
                             <Box
-                                {...compositeReadModeProps}
+                                {...renamableModeProps}
                                 sx={mergeSx(
                                     networkModificationTableStyles.modificationLabel,
                                     createModificationNameCellStyle(row.original.activated),
-                                    compositeReadModeProps.sx
+                                    renamableModeProps.sx
                                 )}
                             >
                                 {label}

--- a/src/features/network-modification-table/row/modification-row.tsx
+++ b/src/features/network-modification-table/row/modification-row.tsx
@@ -28,6 +28,8 @@ interface ModificationRowProps {
     handleCellClick?: (modification: ComposedModificationMetadata) => void;
     isRowDragDisabled: boolean;
     highlightedModificationUuid: string | null;
+    // TODO temporary before GRD-5139
+    isFormOpeningLocked?: boolean;
 }
 
 export function ModificationRow({
@@ -36,6 +38,7 @@ export function ModificationRow({
     handleCellClick,
     isRowDragDisabled,
     highlightedModificationUuid,
+    isFormOpeningLocked = false,
 }: Readonly<ModificationRowProps>) {
     const isHighlighted = row.original.uuid === highlightedModificationUuid;
     const theme = useTheme();
@@ -44,11 +47,11 @@ export function ModificationRow({
 
     const handleCellClickCallback = useCallback(
         (columnId: string) => {
-            if (columnId === BASE_MODIFICATION_TABLE_COLUMNS.NAME.id) {
+            if (columnId === BASE_MODIFICATION_TABLE_COLUMNS.NAME.id && !isFormOpeningLocked) {
                 handleCellClick?.(row.original);
             }
         },
-        [handleCellClick, row.original]
+        [handleCellClick, row.original, isFormOpeningLocked]
     );
 
     return (

--- a/src/features/network-modification-table/use-modifications-drag-and-drop.tsx
+++ b/src/features/network-modification-table/use-modifications-drag-and-drop.tsx
@@ -114,6 +114,20 @@ export const useModificationsDragAndDrop = ({
 
     const isDropForbidden = useCallback(
         (sourceRow: Row<ComposedModificationMetadata>, targetRow: Row<ComposedModificationMetadata>): boolean => {
+            // Without the write permission, nothing can be dragged out of, into or within a shared modification.
+            const { lockedNestedModificationUuids, readOnlySharedModificationUuids } =
+                table.options.meta?.permissions ?? {};
+            if (
+                lockedNestedModificationUuids?.has(sourceRow.original.uuid) ||
+                lockedNestedModificationUuids?.has(targetRow.original.uuid)
+            ) {
+                return true;
+            }
+            // Landing on an expanded shared modification means entering it, which is a write into its content.
+            if (readOnlySharedModificationUuids?.has(targetRow.original.uuid) && targetRow.getIsExpanded()) {
+                return true;
+            }
+
             if (isCompositeModification(sourceRow.original)) {
                 const targetDepth = computeTargetDepth(sourceRow, targetRow);
                 return (
@@ -129,7 +143,7 @@ export const useModificationsDragAndDrop = ({
 
             return false;
         },
-        [computeTargetDepth]
+        [computeTargetDepth, table]
     );
 
     const handleDragUpdate = useCallback(

--- a/src/features/network-modification-table/use-shared-modifications-permissions.ts
+++ b/src/features/network-modification-table/use-shared-modifications-permissions.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import type { UUID } from 'node:crypto';
+import { hasElementPermission, PermissionType } from '../../services';
+import { equalsArrayAnyOrder, NetworkModificationMetadata } from '../../utils';
+import { NotificationsUrlKeys } from '../../utils/constants/notificationsProvider';
+import { useNotificationsListener } from '../notifications/hooks/useNotificationsListener';
+import { isSharedModification } from './utils';
+
+const EMPTY_UUID_SET: Set<UUID> = new Set();
+
+// The directory server has no notification dedicated to permissions: any change on a directory - including
+// the ones on its permissions - is emitted under this single type.
+// See useStudyPath
+// TODO mutualize this with enum
+const UPDATE_DIRECTORY_NOTIFICATION_TYPE = 'UPDATE_DIRECTORY';
+
+/** The distinct elements referenced by the given shared modifications. */
+function getReferenceIds(sharedModifications: NetworkModificationMetadata[]): UUID[] {
+    return [
+        ...new Set(
+            sharedModifications
+                .map((modification) => modification.referenceId)
+                .filter((id): id is UUID => id !== undefined)
+        ),
+    ];
+}
+
+/**
+ * @param sharedModifications the shared modifications of the current node
+ * @param permissions referenceId -> whether the user has the write permission on it
+ * @return the uuids of the shared modifications whose referenced element can't be written into
+ */
+function buildReadOnlySharedModificationUuids(
+    sharedModifications: NetworkModificationMetadata[],
+    permissions: Map<UUID, boolean>
+): Set<UUID> {
+    return new Set(
+        sharedModifications
+            .filter((modification) => !!modification.referenceId && !permissions.get(modification.referenceId))
+            .map((modification) => modification.uuid)
+    );
+}
+
+/**
+ * State updater keeping the previous Set when the new one has the same content. The answer rarely changes
+ * from one resolution to the next, and an unchanged reference spares the consumers a tree walk and a re-render.
+ */
+function replaceIfChanged(nextUuids: Set<UUID>) {
+    return (previousUuids: Set<UUID>) =>
+        equalsArrayAnyOrder([...previousUuids], [...nextUuids]) ? previousUuids : nextUuids;
+}
+
+/**
+ * Resolves the write permission the current user has on the shared modifications of a node.
+ *
+ * A shared modification carries the uuid of the composite it references, which is also the uuid of the
+ * corresponding element in the directory - so its permission is the one of the directory holding that element.
+ *
+ * @param modifications the modifications of the current node, as returned by the server
+ * @return the uuids of the shared modification **rows** the user is not allowed to write into
+ */
+// TODO a permission granted through a group stays cached when the user is added to / removed from that group:
+// user-admin-server emits no notification on group membership changes, unlike directory-server on permissions.
+// Also consider deleting this hook on using Redux instead if we start using permissions at several places.
+export function useSharedModificationsPermissions(modifications: NetworkModificationMetadata[]): {
+    readOnlySharedModificationUuids: Set<UUID>;
+} {
+    const [readOnlySharedModificationUuids, setReadOnlySharedModificationUuids] = useState<Set<UUID>>(EMPTY_UUID_SET);
+    // referenceId -> has the write permission
+    const [permissionsCache, setPermissionsCache] = useState<Map<UUID, boolean>>(() => new Map());
+
+    // A directory notification may carry a permission change, which would make the cached answers wrong. It
+    // doesn't tell which elements are affected - only which directory - and an element's directory is unknown
+    // here, so the whole cache is dropped.
+    const handleDirectoryNotification = useCallback((event: MessageEvent<string>) => {
+        const eventData = JSON.parse(event.data);
+        if (eventData.headers?.notificationType === UPDATE_DIRECTORY_NOTIFICATION_TYPE) {
+            setPermissionsCache(new Map());
+        }
+    }, []);
+
+    useNotificationsListener(NotificationsUrlKeys.DIRECTORY, {
+        listenerCallbackMessage: handleDirectoryNotification,
+    });
+
+    useEffect(() => {
+        let aborted = false;
+
+        const sharedModifications = modifications.filter(isSharedModification);
+        const referenceIds = getReferenceIds(sharedModifications);
+
+        const missingIds = referenceIds.filter((id) => !permissionsCache.has(id));
+        if (missingIds.length === 0) {
+            setReadOnlySharedModificationUuids(
+                replaceIfChanged(
+                    referenceIds.length === 0
+                        ? EMPTY_UUID_SET
+                        : buildReadOnlySharedModificationUuids(sharedModifications, permissionsCache)
+                )
+            );
+            // no fetch needed
+            return undefined;
+        }
+
+        // TODO batch endpoint
+        Promise.all(missingIds.map((id) => hasElementPermission(id, PermissionType.WRITE))).then((permissions) => {
+            if (aborted) {
+                return;
+            }
+            setPermissionsCache((previousCache) => {
+                const nextCache = new Map(previousCache);
+                missingIds.forEach((id, index) => nextCache.set(id, permissions[index]));
+                return nextCache;
+            });
+        });
+
+        return () => {
+            aborted = true;
+        };
+    }, [modifications, permissionsCache]);
+
+    return { readOnlySharedModificationUuids };
+}

--- a/src/features/network-modification-table/utils.ts
+++ b/src/features/network-modification-table/utils.ts
@@ -18,12 +18,58 @@ export const formatToComposedModification = (
     return modifications.map((modification) => ({ ...modification, subModifications: [] }));
 };
 
-export function isCompositeModification(modification: ComposedModificationMetadata | undefined) {
+export function isCompositeModification(modification: NetworkModificationMetadata | undefined) {
     return modification?.type === MODIFICATION_TYPES.COMPOSITE_MODIFICATION.type;
 }
 
-export function isSharedModification(modification: ComposedModificationMetadata | undefined) {
+export function isSharedModification(modification: NetworkModificationMetadata | undefined) {
     return modification?.type === MODIFICATION_TYPES.MODIFICATION_REFERENCE.type;
+}
+
+/**
+ * Tells whether a modification can't be edited because of the permissions on a shared modification: either it
+ * is a shared modification the user can't write into, or it sits inside one.
+ */
+export function isModificationEditLocked(
+    uuid: UUID,
+    readOnlySharedModificationUuids: Set<UUID> | undefined,
+    lockedNestedModificationUuids: Set<UUID> | undefined
+): boolean {
+    return !!readOnlySharedModificationUuids?.has(uuid) || !!lockedNestedModificationUuids?.has(uuid);
+}
+
+/**
+ * Collects the uuids of everything nested inside the given shared modifications, at any depth.
+ *
+ * Those are the modifications the user isn't allowed to touch when he has no write permission on the shared
+ * modification holding them. The shared modifications themselves are deliberately left out: acting on one as
+ * a whole (moving it, deleting it, assembling it into a composite) stays allowed.
+ *
+ * @param readOnlySharedModificationUuids uuids of the shared modifications the user can't write into
+ * @param mods all the modifications of the tree
+ */
+export function collectLockedNestedModificationUuids(
+    readOnlySharedModificationUuids: Set<UUID>,
+    mods: ComposedModificationMetadata[]
+): Set<UUID> {
+    const locked = new Set<UUID>();
+
+    const collectAll = (mod: ComposedModificationMetadata) => {
+        locked.add(mod.uuid);
+        mod.subModifications?.forEach(collectAll);
+    };
+    const visit = (currentMods: ComposedModificationMetadata[], insideReadOnlyShared: boolean) => {
+        currentMods.forEach((mod) => {
+            if (insideReadOnlyShared) {
+                collectAll(mod);
+            } else {
+                visit(mod.subModifications ?? [], readOnlySharedModificationUuids.has(mod.uuid));
+            }
+        });
+    };
+    visit(mods, false);
+
+    return locked;
 }
 
 // returns the depth of the modification with the given uuid in the given mods tree

--- a/src/module-tanstack.d.ts
+++ b/src/module-tanstack.d.ts
@@ -31,6 +31,13 @@ declare module '@tanstack/react-table' {
             isRowDragDisabled?: boolean;
             modificationToEditLabel: RefObject<UUID | null>;
         };
+        permissions: {
+            // shared modifications the user can't write into
+            readOnlySharedModificationUuids?: Set<UUID>;
+            // everything nested inside those, at any depth - the shared modifications themselves are NOT part
+            // of it, so that acting on one as a whole stays allowed
+            lockedNestedModificationUuids?: Set<UUID>;
+        };
         status: {
             isImpactedByNotification?: () => boolean;
             notificationMessageId?: string;

--- a/src/utils/types/network-modification-metadata.ts
+++ b/src/utils/types/network-modification-metadata.ts
@@ -17,6 +17,8 @@ export interface NetworkModificationMetadata {
     description: string;
     messageType: string;
     messageValues: string;
+    // MODIFICATION_REFERENCE only: uuid of the referenced composite modification
+    referenceId?: UUID;
 }
 
 export interface ComposedModificationMetadata extends NetworkModificationMetadata {


### PR DESCRIPTION
## PR Summary

Investigation/POC: honour the WRITE permission on shared modifications inside a study's modification table.

A shared modification is a `MODIFICATION_REFERENCE` carrying a `referenceId`, which is also the `elementUuid` of
the composite in directory-server. `use-shared-modifications-permissions` resolves
`hasElementPermission(referenceId, WRITE)` per shared modification, caches the answers and invalidates them on
`UPDATE_DIRECTORY` notifications.

Two distinct sets are exposed: `readOnlySharedModificationUuids` (the shared modifications the user cannot write
into) and `lockedNestedModificationUuids` (their content). Actions on the shared modification as a whole stay
allowed — only its content is locked: cell editing, rename, description save, form opening, drag source and
target.

Requires gridsuite/network-modification-server#858: without `referenceId` in the metadata nothing locks, so that
one has to be merged first.

Limitations left as TODO in the code: one permission call per reference (`/elements/authorized` is
all-or-nothing, no batch endpoint), and a permission granted through a group is not invalidated —
user-admin-server emits no notification on group composition change.
