### PR TITLE
fix(LineModification): restore the clearable symbol in PATL field

### DIFF
--- a/src/features/network-modifications/common/currentLimits/LimitsPane.tsx
+++ b/src/features/network-modifications/common/currentLimits/LimitsPane.tsx
@@ -38,13 +38,13 @@ const limitsStyles = {
 export interface LimitsPaneProps {
     id?: string;
     equipmentToModify?: BranchInfos | null;
-    clearableFields?: boolean;
+    isModification?: boolean;
 }
 
 export function LimitsPane({
     id = FieldConstants.LIMITS,
     equipmentToModify,
-    clearableFields,
+    isModification,
 }: Readonly<LimitsPaneProps>) {
     const [indexSelectedLimitSet, setIndexSelectedLimitSet] = useState<number | null>(null);
     const { getValues, reset } = useFormContext();
@@ -211,7 +211,7 @@ export function LimitsPane({
                                     <LimitsEditor
                                         key={operationalLimitsGroup.id}
                                         name={`${id}.${FieldConstants.OPERATIONAL_LIMITS_GROUPS}[${index}]`}
-                                        clearableFields={clearableFields}
+                                        clearableFields={isModification}
                                         permanentCurrentLimitPreviousValue={
                                             getCurrentLimits(equipmentToModify, operationalLimitsGroup.id)
                                                 ?.permanentLimit ??

--- a/src/features/network-modifications/line/common/LineDialogTabsContent.tsx
+++ b/src/features/network-modifications/line/common/LineDialogTabsContent.tsx
@@ -24,7 +24,6 @@ export function LineDialogTabsContent({
     lineToModify,
     isModification = false,
     withConnectivity = true,
-    clearableFields = false,
     tabIndex,
     voltageLevelOptions = [],
     PositionDiagramPane,
@@ -48,7 +47,7 @@ export function LineDialogTabsContent({
                 <LineCharacteristicsPane lineToModify={lineToModify} isModification={isModification} />
             </Box>
             <Box hidden={tabIndex !== LineDialogTab.LIMITS_TAB}>
-                <LimitsPane equipmentToModify={lineToModify} clearableFields={clearableFields} />
+                <LimitsPane equipmentToModify={lineToModify} isModification={isModification} />
             </Box>
             {isModification && (
                 <Box hidden={tabIndex !== LineDialogTab.STATE_ESTIMATION_TAB}>

--- a/src/features/network-modifications/line/common/LineForm.tsx
+++ b/src/features/network-modifications/line/common/LineForm.tsx
@@ -22,7 +22,6 @@ export function LineForm({
     PositionDiagramPane,
     isModification = false,
     withConnectivity = true,
-    clearableFields = false,
 }: Readonly<LineFormProps>) {
     const { tabIndex, setTabIndex, tabIndexesWithError } = useTabsWithError<LineDialogTab>(
         LINE_TAB_FIELDS,
@@ -48,7 +47,6 @@ export function LineForm({
                     PositionDiagramPane={PositionDiagramPane}
                     isModification={isModification}
                     withConnectivity={withConnectivity}
-                    clearableFields={clearableFields}
                 />
             </Box>
         </Stack>

--- a/src/features/network-modifications/line/common/line.utils.ts
+++ b/src/features/network-modifications/line/common/line.utils.ts
@@ -10,7 +10,6 @@ import { FieldConstants } from '../../../../utils';
 export interface LineDialogOptions {
     isModification?: boolean;
     withConnectivity?: boolean;
-    clearableFields?: boolean;
 }
 
 export const enum LineDialogTab {


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
After moving LineModification form to commons-ui, the PATL field did'nt have the clearable symbol  anymore (the X symbol).




