### PR TITLE
WIP first try authenticate websocket on first message

### DIFF
--- a/src/features/notifications/NotificationsProvider.tsx
+++ b/src/features/notifications/NotificationsProvider.tsx
@@ -19,11 +19,6 @@ function isUrlDefined(tuple: [string, string | undefined]): tuple is [string, st
     return tuple[1] !== undefined;
 }
 
-function appendTokenToUrl(url: string, token: string): string {
-    const sep = url.includes('?') ? '&' : '?';
-    return `${url}${sep}access_token=${encodeURIComponent(token)}`;
-}
-
 export type NotificationsProviderProps = { urls: Record<string, string | undefined> };
 export function NotificationsProvider({ urls, children }: PropsWithChildren<NotificationsProviderProps>) {
     const {
@@ -54,9 +49,7 @@ export function NotificationsProvider({ urls, children }: PropsWithChildren<Noti
         const connections = Object.entries(urls)
             .filter(isUrlDefined)
             .map(([urlKey, url]) => {
-                // URL lambda: called by ReconnectingWebSocket on each (re)connect, so reconnections always uses the
-                // current token without putting the token in the effect deps (which would recreate the WS on every silent renew).
-                const rws = new ReconnectingWebSocket(() => appendTokenToUrl(url, getUserToken() ?? ''), [], {
+                const rws = new ReconnectingWebSocket(url, [], {
                     // this option set the minimum duration being connected before reset the retry count to 0
                     minUptime: DELAY_BEFORE_WEBSOCKET_CONNECTED,
                 });
@@ -71,6 +64,11 @@ export function NotificationsProvider({ urls, children }: PropsWithChildren<Noti
                 };
 
                 rws.onopen = () => {
+                    // The gateway does not accept a token in the URL/query params for this connection: instead, it expects
+                    // the very first message sent by the client to be the authentication token. We send it here, on every
+                    // (re)connect, so that reconnections always use the current token without putting the token in the
+                    // effect deps (which would recreate the WS on every silent renew).
+                    rws.send(getUserToken() ?? '');
                     console.info(`${urlKey} Notification Websocket connected`);
                     broadcastOnReopen(urlKey)();
                 };

--- a/src/features/notifications/test/NotificationsProvider.test.tsx
+++ b/src/features/notifications/test/NotificationsProvider.test.tsx
@@ -48,7 +48,27 @@ describe('NotificationsProvider', () => {
         act(() => {
             root.render(<NotificationsProvider urls={{ [WS_KEY]: 'test' }} />);
         });
-        expect(ReconnectingWebSocket).toHaveBeenCalled();
+        // the token must never be appended to the URL: it is now sent as the first websocket message instead
+        expect(ReconnectingWebSocket).toHaveBeenCalledWith('test', [], expect.anything());
+    });
+
+    test('sends the current token as the first message once the websocket connects', () => {
+        const root = createRoot(container);
+
+        const sendMock = jest.fn();
+        const reconnectingWebSocketClass = {
+            send: sendMock,
+        } as Partial<ReconnectingWebSocket> as jest.Mocked<ReconnectingWebSocket>;
+        MockedReconnectingWebSocket.mockImplementation(() => reconnectingWebSocketClass);
+
+        act(() => {
+            root.render(<NotificationsProvider urls={{ [WS_KEY]: 'test' }} />);
+        });
+        act(() => {
+            reconnectingWebSocketClass.onopen?.({} as Event);
+        });
+
+        expect(sendMock).toHaveBeenCalledWith('fake-token');
     });
 
     test('renders NotificationsProvider children component ', () => {


### PR DESCRIPTION
For now only oneshot result of junie/sonnet 5.0/Medium on the following prompt: "add sending the token as the first message instead of in the url." (in the same session as the backend gateway websocket handling of this message see https://github.com/gridsuite/gateway/pull/178 )


